### PR TITLE
Make `list` backwards compatible with origin

### DIFF
--- a/test/framework/list.go
+++ b/test/framework/list.go
@@ -32,7 +32,7 @@ var _ = Describe("[sig-testing] example-tests list", Label("framework"), func() 
 
 func runList(args ...string) e.ExtensionTestSpecs {
 	var result e.ExtensionTestSpecs
-	args = append([]string{"list"}, args...)
+	args = append([]string{"list", "tests"}, args...)
 	cmd := exec.Command(binary, args...)
 	output, err := cmd.Output()
 	Expect(err).ShouldNot(HaveOccurred(), "Expected `example-tests info` to run successfully")


### PR DESCRIPTION
origin's current external binary format for listing tests isn't compatible with OTE's list output (it's richer, and uses different case for fields like Name vs name).

This changes the "list" command so that:

list:       old origin format
list tests: new OTE format

This would allow migrating k8s-tests to use openshift-tests-extension, without having the origin side fully implemented yet for the new interface.