### PR TITLE
go 1.22.0 minimum version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift-eng/openshift-tests-extension
 
-go 1.22.4
+go 1.22.0
 
 require (
 	github.com/google/cel-go v0.17.8


### PR DESCRIPTION
Having this set to 1.22.4 is making kube's tooling pull in 1.22.4 instead of 1.22.0, and then failing its verify job.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2105/pull-ci-openshift-kubernetes-master-verify/1843398408929284096
