### PR TITLE
Modify after/before each hooks to take a result / spec parameter

### DIFF
--- a/cmd/example-tests/main.go
+++ b/cmd/example-tests/main.go
@@ -53,21 +53,30 @@ func main() {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))
 	}
 
-	// You can add hooks to run before/after tests. "Each" functions must
-	// be thread safe.
+	// You can add hooks to run before/after tests. There are BeforeEach, BeforeAll, AfterEach,
+	// and AfterAll. "Each" functions must be thread safe.
 	//
-	// 	specs.AddBeforeEach(func() {
+	// specs.AddBeforeAll(func() {
+	// 	initializeTestFramework()
+	// })
+	//
+	// specs.AddBeforeEach(func(spec ExtensionTestSpec) {
+	//	if spec.Name == "my test" {
 	//		// do stuff
-	//	})
+	//	}
+	// })
 	//
-	//	Also: AddBeforeAll, AddAfterEach, AddAfterAll
+	// specs.AddAfterEach(func(res *ExtensionTestResult) {
+	// 	if res.Result == ResultFailed && apiTimeoutRegexp.Matches(res.Output) {
+	// 		res.AddDetails("api-timeout", collectDiagnosticInfo())
+	// 	}
+	// })
 
 	// You can also manually build a test specs list from other testing tooling
 	// TODO: example
 
-	// Modify specs:
-	// Add label to all specs
-	// specs = specs.AddLabel("SLOW")
+	// Modify specs, such as adding a label to all specs
+	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
 	// specs = specs.MustFilter([]string{`name.contains("filter")`})
@@ -83,6 +92,7 @@ func main() {
 	//		spec.OtherNames = sets.New[string](`[sig-testing] openshift-tests-extension has a test with a tpyo`)
 	//	}
 	// })
+
 	ext.AddSpecs(specs)
 	registry.Register(ext)
 

--- a/pkg/extension/extensiontests/result.go
+++ b/pkg/extension/extensiontests/result.go
@@ -6,6 +6,7 @@ func (results ExtensionTestResults) Walk(walkFn func(*ExtensionTestResult)) {
 	}
 }
 
+// AddDetails adds additional information to an ExtensionTestResult. Value must marshal to JSON.
 func (result *ExtensionTestResult) AddDetails(name string, value interface{}) {
 	result.Details = append(result.Details, Details{Name: name, Value: value})
 }

--- a/pkg/extension/extensiontests/result.go
+++ b/pkg/extension/extensiontests/result.go
@@ -5,3 +5,7 @@ func (results ExtensionTestResults) Walk(walkFn func(*ExtensionTestResult)) {
 		walkFn(results[i])
 	}
 }
+
+func (result *ExtensionTestResult) AddDetails(name string, value interface{}) {
+	result.Details = append(result.Details, Details{Name: name, Value: value})
+}

--- a/pkg/extension/extensiontests/spec_test.go
+++ b/pkg/extension/extensiontests/spec_test.go
@@ -222,12 +222,12 @@ func TestExtensionTestSpecs_HookExecution(t *testing.T) {
 				})
 			}
 			if tc.expectedBeforeEach > 0 {
-				specs.AddBeforeEach(func() {
+				specs.AddBeforeEach(func(_ ExtensionTestSpec) {
 					beforeEachCount.Add(1)
 				})
 			}
 			if tc.expectedAfterEach > 0 {
-				specs.AddAfterEach(func() {
+				specs.AddAfterEach(func(_ *ExtensionTestResult) {
 					afterEachCount.Add(1)
 				})
 			}

--- a/pkg/extension/extensiontests/task.go
+++ b/pkg/extension/extensiontests/task.go
@@ -2,16 +2,20 @@ package extensiontests
 
 import "sync/atomic"
 
-type Task interface {
-	Run()
+type SpecTask struct {
+	fn func(spec ExtensionTestSpec)
 }
 
-type RepeatableTask struct {
-	fn func()
+func (t *SpecTask) Run(spec ExtensionTestSpec) {
+	t.fn(spec)
 }
 
-func (t *RepeatableTask) Run() {
-	t.fn()
+type TestResultTask struct {
+	fn func(result *ExtensionTestResult)
+}
+
+func (t *TestResultTask) Run(result *ExtensionTestResult) {
+	t.fn(result)
 }
 
 type OneTimeTask struct {

--- a/pkg/extension/extensiontests/task_test.go
+++ b/pkg/extension/extensiontests/task_test.go
@@ -1,0 +1,60 @@
+package extensiontests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOneTimeTask_RunActuallyOnlyRunsOnce(t *testing.T) {
+	actualExecutionCount := 0
+	task := &OneTimeTask{
+		fn: func() {
+			actualExecutionCount++
+		},
+	}
+
+	var wg sync.WaitGroup
+	maxConcurrency := 10
+	throttle := make(chan struct{}, maxConcurrency)
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		throttle <- struct{}{}
+
+		go func() {
+			defer wg.Done()
+			task.Run()
+			<-throttle
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, task.executed, int32(1))
+	assert.Equal(t, actualExecutionCount, 1)
+}
+
+func TestSpecTask_RunMustNotMutate(t *testing.T) {
+	originalName := "this is a test"
+	mySpec := ExtensionTestSpec{Name: originalName}
+	task := &SpecTask{
+		fn: func(spec ExtensionTestSpec) {
+			assert.Equal(t, mySpec.Name, spec.Name)
+			spec.Name = "trying to mutate the spec should fail"
+		},
+	}
+	task.Run(mySpec)
+	assert.Equal(t, mySpec.Name, originalName)
+}
+
+func TestTestResultTask_RunMayMutate(t *testing.T) {
+	myRes := &ExtensionTestResult{Name: "this is a test", Result: ResultPassed}
+	task := &TestResultTask{
+		fn: func(result *ExtensionTestResult) {
+			result.Result = ResultFailed
+		},
+	}
+	task.Run(myRes)
+	assert.Equal(t, myRes.Result, ResultFailed)
+}

--- a/pkg/extension/extensiontests/types.go
+++ b/pkg/extension/extensiontests/types.go
@@ -18,13 +18,13 @@ type ExtensionTestSpec struct {
 
 	// OtherNames contains a list of historical names for this test. If the test gets renamed in the future,
 	// this slice must report all the previous names for this test to preserve history.
-	OtherNames sets.Set[string] `json:"otherNames"`
+	OtherNames sets.Set[string] `json:"otherNames,omitempty"`
 
 	// Labels are single string values to apply to the test spec
 	Labels sets.Set[string] `json:"labels"`
 
 	// Tags are key:value pairs
-	Tags map[string]string `json:"tags"`
+	Tags map[string]string `json:"tags,omitempty"`
 
 	// Resources gives optional information about what's required to run this test.
 	Resources Resources `json:"resources"`
@@ -38,26 +38,26 @@ type ExtensionTestSpec struct {
 	// Tests must not remain informing forever.
 	Lifecycle Lifecycle `json:"lifecycle"`
 
-	// Run invokes a test (TODO:relace gingko spec state with our own)
+	// Run invokes a test
 	Run func() *ExtensionTestResult `json:"-"`
 
 	// Hook functions
-	afterAll   []Task
-	beforeAll  []Task
-	afterEach  []Task
-	beforeEach []Task
+	afterAll   []*OneTimeTask
+	beforeAll  []*OneTimeTask
+	afterEach  []*TestResultTask
+	beforeEach []*SpecTask
 }
 
 type Resources struct {
 	Isolation Isolation `json:"isolation"`
-	Memory    string    `json:"memory"`
-	Duration  string    `json:"duration"`
-	Timeout   string    `json:"timeout"`
+	Memory    string    `json:"memory,omitempty"`
+	Duration  string    `json:"duration,omitempty"`
+	Timeout   string    `json:"timeout,omitempty"`
 }
 
 type Isolation struct {
-	Mode     string   `json:"mode"`
-	Conflict []string `json:"conflict"`
+	Mode     string   `json:"mode,omitempty"`
+	Conflict []string `json:"conflict,omitempty"`
 }
 
 type ExtensionTestResults []*ExtensionTestResult
@@ -76,6 +76,15 @@ type ExtensionTestResult struct {
 	EndTime   *dbtime.DBTime `json:"endTime"`
 	Result    Result         `json:"result"`
 	Output    string         `json:"output"`
-	Error     string         `json:"error"`
-	Details   []string       `json:"details"`
+	Error     string         `json:"error,omitempty"`
+	Details   []Details      `json:"details,omitempty"`
+}
+
+// Details are human-readable messages to further explain skips, timeouts, etc.
+// It can also be used to provide contemporaneous information about failures
+// that may not be easily returned by must-gather. For larger artifacts (greater than
+// 10KB, write them to $EXTENSION_ARTIFACTS_DIR.
+type Details struct {
+	Name  string      `json:"name"`
+	Value interface{} `json:"value"`
 }


### PR DESCRIPTION
Allows a beforeEach to know the context it's operating in (but not modify it).

Allows an afterEach to modify a test result, collect diagnostics, etc.

Also aligns details to the enhancement.
