### PR TITLE
Add FIPS compliance override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,16 @@ verify: lint
 build: example-tests framework-tests
 
 example-tests:
-	go build -ldflags "$(LDFLAGS)" ./cmd/example-tests/...
+	# GO_COMPLIANCE_POLICY="exempt_all" must only be used for test related binaries.
+	# It prevents various FIPS compliance policies from being applied to this compilation.
+	# Do not set globally.
+	GO_COMPLIANCE_POLICY="exempt_all" go build -ldflags "$(LDFLAGS)" ./cmd/example-tests/...
 
 framework-tests:
-	go build -ldflags "$(LDFLAGS)" ./cmd/framework-tests/...
+	# GO_COMPLIANCE_POLICY="exempt_all" must only be used for test related binaries.
+	# It prevents various FIPS compliance policies from being applied to this compilation.
+	# Do not set globally.
+	GO_COMPLIANCE_POLICY="exempt_all" go build -ldflags "$(LDFLAGS)" ./cmd/framework-tests/...
 
 test: unit integration
 


### PR DESCRIPTION
When ART is compiling for production builds, a wrapper around "go" is employed to force FIPS compliant compilation. For example, static linking will be transparently replaced with dynamically link and "FIPS or Die" mode will be enabled.
We want extension binaries to be statically linked so that they are not sensitive to being copied into a container with a different environment. "exempt_all" permits this, even for ART production builds.