### PR TITLE
Set name on result from spec

### DIFF
--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -72,6 +72,10 @@ func (specs ExtensionTestSpecs) Run(w ResultWriter, maxConcurrent int) error {
 				for _, afterEachTask := range spec.afterEach {
 					afterEachTask.Run(res)
 				}
+
+				// We can't assume the runner will set the name of a test; it may not know it. Even if
+				// it does, we may want to modify it (e.g. k8s-tests for annotations currently).
+				res.Name = spec.Name
 				w.Write(res)
 			}
 		}()


### PR DESCRIPTION
We can't assume the runner for a test will set the name in its result, it may not know it.  Ginkgo does, although even then we shouldn't accept its name of the spec because we might've modified it, like k8s-tests does[1].

[1] https://github.com/openshift/kubernetes/blob/a3f31a4f2c587420f1ddb3bcdb161bf64a8c436b/openshift-hack/cmd/k8s-tests-ext/k8s-tests.go#L83-L87