### PR TITLE
bug: use StringArrayVarP instead of Slice

### DIFF
--- a/pkg/flags/names.go
+++ b/pkg/flags/names.go
@@ -16,7 +16,7 @@ func NewNamesFlags() *NamesFlags {
 }
 
 func (f *NamesFlags) BindFlags(fs *pflag.FlagSet) {
-	fs.StringSliceVarP(&f.Names,
+	fs.StringArrayVarP(&f.Names,
 		"names",
 		"n",
 		f.Names,


### PR DESCRIPTION
SliceVarP allows comma-separated values, which seems unescapable.  Some tests have commas so it was getting split into multiple parts (and causing errors in not finding those tests).  StringArrayVarP is strictly one value per invocation and won't try to split the value.

Tests with commas ended up producing results like this:

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/7b8de33c-0b51-4225-a9b3-b490ee77ce04" />
