### PR TITLE
environment flag updates

### DIFF
--- a/pkg/extension/extensiontests/environment.go
+++ b/pkg/extension/extensiontests/environment.go
@@ -29,6 +29,28 @@ func ArchitectureEquals(arch string) string {
 	return fmt.Sprintf(`architecture=="%s"`, arch)
 }
 
+func ExternalConnectivityEquals(externalConnectivity string) string {
+	return fmt.Sprintf(`externalConnectivity=="%s"`, externalConnectivity)
+}
+
+func OptionalCapabilitiesIncludeAny(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " || ")))
+}
+
+func OptionalCapabilitiesIncludeAll(optionalCapability ...string) string {
+	for i := range optionalCapability {
+		optionalCapability[i] = OptionalCapabilityExists(optionalCapability[i])
+	}
+	return fmt.Sprintf("(%s)", fmt.Sprint(strings.Join(optionalCapability, " && ")))
+}
+
+func OptionalCapabilityExists(optionalCapability string) string {
+	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
+}
+
 func InstallerEquals(installer string) string {
 	return fmt.Sprintf(`installer=="%s"`, installer)
 }

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -79,6 +79,18 @@ func NameContains(name string) SelectFunction {
 	}
 }
 
+// NameContainsAll returns a function that selects specs whose name contains each of the provided contents strings
+func NameContainsAll(contents ...string) SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		for _, content := range contents {
+			if !strings.Contains(spec.Name, content) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // HasLabel returns a function that selects specs with the provided label
 func HasLabel(label string) SelectFunction {
 	return func(spec *ExtensionTestSpec) bool {

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -319,7 +319,8 @@ func (specs ExtensionTestSpecs) FilterByEnvironment(envFlags flags.Environmental
 			decls.NewVar("upgrade", decls.String),
 			decls.NewVar("topology", decls.String),
 			decls.NewVar("architecture", decls.String),
-			decls.NewVar("installer", decls.String),
+			decls.NewVar("externalConnectivity", decls.String),
+			decls.NewVar("optionalCapabilities", decls.NewListType(decls.String)),
 			decls.NewVar("facts", decls.NewMapType(decls.String, decls.String)),
 			decls.NewVar("fact_keys", decls.NewListType(decls.String)),
 			decls.NewVar("version", decls.String),
@@ -333,16 +334,17 @@ func (specs ExtensionTestSpecs) FilterByEnvironment(envFlags flags.Environmental
 		factKeys = append(factKeys, k)
 	}
 	vars := map[string]interface{}{
-		"platform":     envFlags.Platform,
-		"network":      envFlags.Network,
-		"networkStack": envFlags.NetworkStack,
-		"upgrade":      envFlags.Upgrade,
-		"topology":     envFlags.Topology,
-		"architecture": envFlags.Architecture,
-		"installer":    envFlags.Installer,
-		"facts":        envFlags.Facts,
-		"fact_keys":    factKeys,
-		"version":      envFlags.Version,
+		"platform":             envFlags.Platform,
+		"network":              envFlags.Network,
+		"networkStack":         envFlags.NetworkStack,
+		"upgrade":              envFlags.Upgrade,
+		"topology":             envFlags.Topology,
+		"architecture":         envFlags.Architecture,
+		"externalConnectivity": envFlags.ExternalConnectivity,
+		"optionalCapabilities": envFlags.OptionalCapabilities,
+		"facts":                envFlags.Facts,
+		"fact_keys":            factKeys,
+		"version":              envFlags.Version,
 	}
 
 	for _, spec := range specs {

--- a/pkg/extension/extensiontests/spec_test.go
+++ b/pkg/extension/extensiontests/spec_test.go
@@ -591,6 +591,23 @@ func TestSelect(t *testing.T) {
 			},
 		},
 		{
+			name: "name contains all",
+			specs: ExtensionTestSpecs{
+				{
+					Name: "aws-only",
+				},
+				{
+					Name: "aws-only-with-some-extra",
+				},
+			},
+			selectFn: NameContainsAll("aws", "some-extra"),
+			want: ExtensionTestSpecs{
+				{
+					Name: "aws-only-with-some-extra",
+				},
+			},
+		},
+		{
 			name: "can return multiple",
 			specs: ExtensionTestSpecs{
 				{

--- a/pkg/extension/extensiontests/spec_test.go
+++ b/pkg/extension/extensiontests/spec_test.go
@@ -430,7 +430,7 @@ func TestExtensionTestSpecs_FilterByEnvironment(t *testing.T) {
 					EnvironmentSelector: EnvironmentSelector{
 						Include: And(
 							Or(
-								PlatformEquals("aws"), NetworkEquals("ovn"), NetworkStackEquals("ipv6")),
+								PlatformEquals("aws"), NetworkEquals("ovn"), NetworkStackEquals("ipv6"), ExternalConnectivityEquals("Disconnected")),
 							And(
 								UpgradeEquals("minor"), TopologyEquals("microshift"), ArchitectureEquals("amd64"),
 							),
@@ -451,13 +451,14 @@ func TestExtensionTestSpecs_FilterByEnvironment(t *testing.T) {
 				},
 			},
 			envFlags: flags.EnvironmentalFlags{
-				Platform:     "aws",
-				Network:      "sdn",
-				NetworkStack: "ipv6",
-				Upgrade:      "minor",
-				Topology:     "microshift",
-				Architecture: "amd64",
-				Version:      "4.18",
+				Platform:             "aws",
+				Network:              "sdn",
+				NetworkStack:         "ipv6",
+				Upgrade:              "minor",
+				Topology:             "microshift",
+				Architecture:         "amd64",
+				Version:              "4.18",
+				ExternalConnectivity: "Disconnected",
 			},
 			want: ExtensionTestSpecs{
 				{
@@ -465,7 +466,7 @@ func TestExtensionTestSpecs_FilterByEnvironment(t *testing.T) {
 					EnvironmentSelector: EnvironmentSelector{
 						Include: And(
 							Or(
-								PlatformEquals("aws"), NetworkEquals("ovn"), NetworkStackEquals("ipv6")),
+								PlatformEquals("aws"), NetworkEquals("ovn"), NetworkStackEquals("ipv6"), ExternalConnectivityEquals("Disconnected")),
 							And(
 								UpgradeEquals("minor"), TopologyEquals("microshift"), ArchitectureEquals("amd64"),
 							),
@@ -509,6 +510,44 @@ func TestExtensionTestSpecs_FilterByEnvironment(t *testing.T) {
 					Name: "only-when-cool",
 					EnvironmentSelector: EnvironmentSelector{
 						Include: And(FactEquals("cool.component", "absolutely")),
+					},
+				},
+			},
+		},
+		{
+			name: "include based on optional capabilities",
+			specs: ExtensionTestSpecs{
+				{
+					Name: "spec-baremetal-build",
+					EnvironmentSelector: EnvironmentSelector{
+						Include: OptionalCapabilitiesIncludeAny("baremetal", "build"),
+					},
+				},
+				{
+					Name: "spec-baremetal-only",
+					EnvironmentSelector: EnvironmentSelector{
+						Include: OptionalCapabilitiesIncludeAll("baremetal"),
+					},
+				},
+				{
+					Name: "spec-build-only",
+					EnvironmentSelector: EnvironmentSelector{
+						Include: OptionalCapabilitiesIncludeAll("build"),
+					},
+				},
+			},
+			envFlags: flags.EnvironmentalFlags{OptionalCapabilities: []string{"baremetal"}},
+			want: ExtensionTestSpecs{
+				{
+					Name: "spec-baremetal-build",
+					EnvironmentSelector: EnvironmentSelector{
+						Include: OptionalCapabilitiesIncludeAny("baremetal", "build"),
+					},
+				},
+				{
+					Name: "spec-baremetal-only",
+					EnvironmentSelector: EnvironmentSelector{
+						Include: OptionalCapabilitiesIncludeAll("baremetal"),
 					},
 				},
 			},

--- a/pkg/flags/environment.go
+++ b/pkg/flags/environment.go
@@ -3,15 +3,16 @@ package flags
 import "github.com/spf13/pflag"
 
 type EnvironmentalFlags struct {
-	Platform     string
-	Network      string
-	NetworkStack string
-	Upgrade      string
-	Topology     string
-	Architecture string
-	Installer    string
-	Facts        map[string]string
-	Version      string
+	Platform             string
+	Network              string
+	NetworkStack         string
+	Upgrade              string
+	Topology             string
+	Architecture         string
+	ExternalConnectivity string
+	OptionalCapabilities []string
+	Facts                map[string]string
+	Version              string
 }
 
 func NewEnvironmentalFlags() *EnvironmentalFlags {
@@ -43,10 +44,14 @@ func (f *EnvironmentalFlags) BindFlags(fs *pflag.FlagSet) {
 		"architecture",
 		"",
 		"The CPU architecture of the target cluster (\"amd64\", \"arm64\"). Since: v1.0")
-	fs.StringVar(&f.Installer,
-		"installer",
+	fs.StringVar(&f.ExternalConnectivity,
+		"external-connectivity",
 		"",
-		"The installer used to create the cluster (\"ipi\", \"upi\", \"assisted\", ...). Since: v1.0")
+		"The External Connectivity of the target cluster (\"Disconnected\", \"Direct\", \"Proxied\"). Since: v1.0")
+	fs.StringSliceVar(&f.OptionalCapabilities,
+		"optional-capability",
+		[]string{},
+		"An Optional Capability of the target cluster. Can be passed multiple times. Since: v1.0")
 	fs.StringToStringVar(&f.Facts,
 		"fact",
 		make(map[string]string),
@@ -64,20 +69,22 @@ func (f *EnvironmentalFlags) IsEmpty() bool {
 		f.Upgrade == "" &&
 		f.Topology == "" &&
 		f.Architecture == "" &&
-		f.Installer == "" &&
+		f.ExternalConnectivity == "" &&
+		f.OptionalCapabilities == nil &&
 		len(f.Facts) == 0 &&
 		f.Version == ""
 }
 
 // EnvironmentFlagVersions holds the "Since" version metadata for each flag.
 var EnvironmentFlagVersions = map[string]string{
-	"platform":      "v1.0",
-	"network":       "v1.0",
-	"network-stack": "v1.0",
-	"upgrade":       "v1.0",
-	"topology":      "v1.0",
-	"architecture":  "v1.0",
-	"installer":     "v1.0",
-	"fact":          "v1.0",
-	"version":       "v1.0",
+	"platform":              "v1.0",
+	"network":               "v1.0",
+	"network-stack":         "v1.0",
+	"upgrade":               "v1.0",
+	"topology":              "v1.0",
+	"architecture":          "v1.0",
+	"external-connectivity": "v1.0",
+	"optional-capability":   "v1.0",
+	"fact":                  "v1.0",
+	"version":               "v1.0",
 }


### PR DESCRIPTION
remove 'installer', add 'optional-capability' and 'external-connectivity'

Also adds a `NameContainsAll` function as that would be very useful for translating the `k8s-tests-ext` skips

For: https://issues.redhat.com/browse/TRT-1853