### PR TITLE
Adjustments to Env Flag helper methods

### DIFF
--- a/pkg/extension/extensiontests/environment.go
+++ b/pkg/extension/extensiontests/environment.go
@@ -51,6 +51,10 @@ func OptionalCapabilityExists(optionalCapability string) string {
 	return fmt.Sprintf(`optionalCapabilities.exists(oc, oc=="%s")`, optionalCapability)
 }
 
+func NoOptionalCapabilitiesExist() string {
+	return "size(optionalCapabilities) == 0"
+}
+
 func InstallerEquals(installer string) string {
 	return fmt.Sprintf(`installer=="%s"`, installer)
 }

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -456,14 +456,26 @@ func (specs ExtensionTestSpecs) Exclude(excludeCEL string) ExtensionTestSpecs {
 	return specs
 }
 
-// Include adds the specified CEL expression to explicitly include tests by environment
+// Include adds the specified CEL expression to explicitly include tests by environment.
+// If there is already an "include" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Include(includeCEL string) *ExtensionTestSpec {
+	existingInclude := spec.EnvironmentSelector.Include
+	if existingInclude != "" {
+		includeCEL = fmt.Sprintf("(%s) || (%s)", existingInclude, includeCEL)
+	}
+
 	spec.EnvironmentSelector.Include = includeCEL
 	return spec
 }
 
-// Exclude adds the specified CEL expression to explicitly exclude tests by environment
+// Exclude adds the specified CEL expression to explicitly exclude tests by environment.
+// If there is already an "exclude" defined, it will OR the expressions together
 func (spec *ExtensionTestSpec) Exclude(excludeCEL string) *ExtensionTestSpec {
+	existingExclude := spec.EnvironmentSelector.Exclude
+	if existingExclude != "" {
+		excludeCEL = fmt.Sprintf("(%s) || (%s)", existingExclude, excludeCEL)
+	}
+
 	spec.EnvironmentSelector.Exclude = excludeCEL
 	return spec
 }


### PR DESCRIPTION
adjust the `Include` and `Exclude` helpers to implicitly OR with the existing expressions and add a helper for `NoOptionalCapabilitiesExist`