### PR TITLE
No-Jira: add `Must*` helpers for each of the flavors of `Select` specs functions that error when nothing is found

### DIFF
--- a/cmd/example-tests/main.go
+++ b/cmd/example-tests/main.go
@@ -101,6 +101,12 @@ func main() {
 	// Or with "all" (and) matching selections
 	// specs = specs.SelectAll(et.NameContains("slow test"), et.HasTagWithValue("speed", "slow"))
 	//
+	// There are also Must* functions for any of the above flavors of selection
+	// which will return an error if nothing is found
+	// specs, err = specs.MustSelect(et.NameContains("slow test")).AddLabel("SLOW")
+	// if err != nil {
+	//    logrus.Warn("no specs found: %w", err)
+	// }
 	// Test renames
 	//	if spec.Name == "[sig-testing] openshift-tests-extension has a test with a typo" {
 	//		spec.OriginalName = `[sig-testing] openshift-tests-extension has a test with a tpyo`

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -38,6 +38,17 @@ func (specs ExtensionTestSpecs) Select(selectFn SelectFunction) ExtensionTestSpe
 	return filtered
 }
 
+// MustSelect filters the ExtensionTestSpecs to only those that match the provided SelectFunction.
+// if no specs are selected, it will throw an error
+func (specs ExtensionTestSpecs) MustSelect(selectFn SelectFunction) (ExtensionTestSpecs, error) {
+	filtered := specs.Select(selectFn)
+	if len(filtered) == 0 {
+		return filtered, fmt.Errorf("no specs selected with specified SelectFunctions")
+	}
+
+	return filtered, nil
+}
+
 // SelectAny filters the ExtensionTestSpecs to only those that match any of the provided SelectFunctions
 func (specs ExtensionTestSpecs) SelectAny(selectFns []SelectFunction) ExtensionTestSpecs {
 	filtered := ExtensionTestSpecs{}
@@ -51,6 +62,17 @@ func (specs ExtensionTestSpecs) SelectAny(selectFns []SelectFunction) ExtensionT
 	}
 
 	return filtered
+}
+
+// MustSelectAny filters the ExtensionTestSpecs to only those that match any of the provided SelectFunctions.
+// if no specs are selected, it will throw an error
+func (specs ExtensionTestSpecs) MustSelectAny(selectFns []SelectFunction) (ExtensionTestSpecs, error) {
+	filtered := specs.SelectAny(selectFns)
+	if len(filtered) == 0 {
+		return filtered, fmt.Errorf("no specs selected with specified SelectFunctions")
+	}
+
+	return filtered, nil
 }
 
 // SelectAll filters the ExtensionTestSpecs to only those that match all the provided SelectFunctions
@@ -70,6 +92,17 @@ func (specs ExtensionTestSpecs) SelectAll(selectFns []SelectFunction) ExtensionT
 	}
 
 	return filtered
+}
+
+// MustSelectAll filters the ExtensionTestSpecs to only those that match all the provided SelectFunctions.
+// if no specs are selected, it will throw an error
+func (specs ExtensionTestSpecs) MustSelectAll(selectFns []SelectFunction) (ExtensionTestSpecs, error) {
+	filtered := specs.SelectAll(selectFns)
+	if len(filtered) == 0 {
+		return filtered, fmt.Errorf("no specs selected with specified SelectFunctions")
+	}
+
+	return filtered, nil
 }
 
 // NameContains returns a function that selects specs whose name contains the provided string


### PR DESCRIPTION
These will be generally useful, but specifically added to alert us when `openshift/kubernetes` test skips are no longer required.

See https://github.com/openshift/kubernetes/pull/2215#pullrequestreview-2686710936