### PR TITLE
Exclude vendored tests by default

### DIFF
--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -118,7 +118,7 @@ func ModuleTestsOnly() SelectFunction {
 	}
 }
 
-// AllTestsIncludingVendored is an alternative to the above, which would explicitly opt-in
+// AllTestsIncludingVendored is an alternative to ModuleTestsOnly, which would explicitly opt-in
 // to including vendored tests.
 func AllTestsIncludingVendored() SelectFunction {
 	return func(spec *ExtensionTestSpec) bool {

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -10,9 +10,9 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker/decls"
 	"github.com/google/cel-go/common/types"
-	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
 )
 
 // Walk iterates over all test specs, and executions the function provided. The test spec can be mutated.
@@ -103,6 +103,27 @@ func (specs ExtensionTestSpecs) MustSelectAll(selectFns []SelectFunction) (Exten
 	}
 
 	return filtered, nil
+}
+
+// ModuleTestsOnly ensures that ginkgo tests from vendored sources aren't selected.
+func ModuleTestsOnly() SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		for _, cl := range spec.CodeLocations {
+			if strings.Contains(cl, "/vendor/") {
+				return false
+			}
+		}
+
+		return true
+	}
+}
+
+// AllTestsIncludingVendored is an alternative to the above, which would explicitly opt-in
+// to including vendored tests.
+func AllTestsIncludingVendored() SelectFunction {
+	return func(spec *ExtensionTestSpec) bool {
+		return true
+	}
 }
 
 // NameContains returns a function that selects specs whose name contains the provided string
@@ -284,6 +305,7 @@ func (specs ExtensionTestSpecs) Filter(celExprs []string) (ExtensionTestSpecs, e
 			decls.NewVar("name", decls.String),
 			decls.NewVar("originalName", decls.String),
 			decls.NewVar("labels", decls.NewListType(decls.String)),
+			decls.NewVar("codeLocations", decls.NewListType(decls.String)),
 			decls.NewVar("tags", decls.NewMapType(decls.String, decls.String)),
 		),
 	)
@@ -300,11 +322,12 @@ func (specs ExtensionTestSpecs) Filter(celExprs []string) (ExtensionTestSpecs, e
 				return nil, err
 			}
 			out, _, err := prg.Eval(map[string]interface{}{
-				"name":         spec.Name,
-				"source":       spec.Source,
-				"originalName": spec.OriginalName,
-				"labels":       spec.Labels.UnsortedList(),
-				"tags":         spec.Tags,
+				"name":          spec.Name,
+				"source":        spec.Source,
+				"originalName":  spec.OriginalName,
+				"labels":        spec.Labels.UnsortedList(),
+				"codeLocations": spec.CodeLocations,
+				"tags":          spec.Tags,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error evaluating CEL expression: %v", err)

--- a/pkg/extension/extensiontests/types.go
+++ b/pkg/extension/extensiontests/types.go
@@ -31,6 +31,9 @@ type ExtensionTestSpec struct {
 	// Source is the origin of the test.
 	Source string `json:"source"`
 
+	// CodeLocations are the files where the spec originates from.
+	CodeLocations []string `json:"codeLocations,omitempty"`
+
 	// Lifecycle informs the executor whether the test is informing only, and should not cause the
 	// overall job run to fail, or if it's blocking where a failure of the test is fatal.
 	// Informing lifecycle tests can be used temporarily to gather information about a test's stability.

--- a/pkg/ginkgo/util.go
+++ b/pkg/ginkgo/util.go
@@ -10,8 +10,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
-	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 	"github.com/pkg/errors"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 
 	ext "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 )
@@ -40,8 +41,12 @@ func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
 	return &suiteConfig, &reporterConfig, nil
 }
 
-func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, error) {
-	var tests []*ext.ExtensionTestSpec
+// BuildExtensionTestSpecsFromOpenShiftGinkgoSuite generates OTE specs for Gingko tests. While OTE isn't limited to
+// calling ginkgo tests, anything that implements the ExtensionTestSpec interface can be used, it's the most common
+// course of action.  The typical use case is to omit selectFns, but if provided, these will filter the returned list
+// of specs, applied in the order provided.
+func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunction) (ext.ExtensionTestSpecs, error) {
+	var specs ext.ExtensionTestSpecs
 	var enforceSerialExecutionForGinkgo sync.Mutex // in-process parallelization for ginkgo is impossible so far
 
 	if _, _, err := configureGinkgo(); err != nil {
@@ -54,10 +59,16 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, 
 	}
 
 	ginkgo.GetSuite().WalkTests(func(name string, spec types.TestSpec) {
+		var codeLocations []string
+		for _, cl := range spec.CodeLocations() {
+			codeLocations = append(codeLocations, cl.String())
+		}
+
 		testCase := &ext.ExtensionTestSpec{
-			Name:      spec.Text(),
-			Labels:    sets.New[string](spec.Labels()...),
-			Lifecycle: GetLifecycle(spec.Labels()),
+			Name:          spec.Text(),
+			Labels:        sets.New[string](spec.Labels()...),
+			CodeLocations: codeLocations,
+			Lifecycle:     GetLifecycle(spec.Labels()),
 			Run: func() *ext.ExtensionTestResult {
 				enforceSerialExecutionForGinkgo.Lock()
 				defer enforceSerialExecutionForGinkgo.Unlock()
@@ -103,10 +114,23 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite() (ext.ExtensionTestSpecs, 
 				return result
 			},
 		}
-		tests = append(tests, testCase)
+		specs = append(specs, testCase)
 	})
 
-	return tests, nil
+	// Default select function is to exclude vendored specs.  When relying on Kubernetes test framework for its helpers,
+	// it also unfortunately ends up importing *all* Gingko specs.  This is unsafe: it would potentially override the
+	// kube specs already present in origin.  The best course of action is enforce this behavior on everyone.  If for
+	// some reason, you must include vendored specs, you can opt-in directly by supplying your own SelectFunctions or using
+	// AllTestsIncludedVendored().
+	if len(selectFns) == 0 {
+		selectFns = []ext.SelectFunction{ext.ModuleTestsOnly()}
+	}
+
+	for _, selectFn := range selectFns {
+		specs = specs.Select(selectFn)
+	}
+
+	return specs, nil
 }
 
 func Informing() ginkgo.Labels {


### PR DESCRIPTION
When relying on Kubernetes test framework for its helpers, it also unfortunately ends up importing *all* its Gingko specs.  This is unsafe: it would potentially override the kube specs already present in origin.

This adds a default selector on Gingko tests that excludes vendored tests.