### PR TITLE
TRT-2097: Align suite options to origin

### DIFF
--- a/pkg/cmd/cmdrun/runsuite.go
+++ b/pkg/cmd/cmdrun/runsuite.go
@@ -24,8 +24,9 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:          "run-suite NAME",
-		Short:        "Run a group of tests by suite",
+		Use: "run-suite NAME",
+		Short: "Run a group of tests by suite. This is more limited than origin, and intended for light local " +
+			"development use. Orchestration parameters, scheduling, isolation, etc are not obeyed, and Ginkgo tests are executed serially.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ext := registry.Get(opts.componentFlags.Component)

--- a/pkg/extension/types.go
+++ b/pkg/extension/types.go
@@ -1,6 +1,8 @@
 package extension
 
 import (
+	"time"
+
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 )
@@ -45,14 +47,40 @@ type Component struct {
 	Name string `json:"name"`
 }
 
-// Suite represents additional suites the extension wants to advertise.
+type ClusterStability string
+
+var (
+	// ClusterStabilityStable means that at no point during testing do we expect a component to take downtime and upgrades are not happening.
+	ClusterStabilityStable ClusterStability = "Stable"
+
+	// ClusterStabilityDisruptive means that the suite is expected to induce outages to the cluster.
+	ClusterStabilityDisruptive ClusterStability = "Disruptive"
+
+	// ClusterStabilityUpgrade was previously defined, but was removed by @deads2k. Please contact him if you find a use
+	// case for it and needs to be reintroduced.
+	// ClusterStabilityUpgrade    ClusterStability = "Upgrade"
+)
+
+// Suite represents additional suites the extension wants to advertise. Child suites when being executed in the context
+// of a parent will have their count, parallelism, stability, and timeout options superseded by the parent's suite.
 type Suite struct {
-	// The name of the suite.
-	Name string `json:"name"`
-	// Parent suites this suite is part of.
+	Name        string `json:"name"`
+	Description string `json:"description"`
+
+	// Parents are the parent suites this suite is part of.
 	Parents []string `json:"parents,omitempty"`
 	// Qualifiers are CEL expressions that are OR'd together for test selection that are members of the suite.
 	Qualifiers []string `json:"qualifiers,omitempty"`
+
+	// Count is the default number of times to execute each test in this suite.
+	Count int `json:"count,omitempty"`
+	// Parallelism is the maximum parallelism of this suite.
+	Parallelism int `json:"parallelism,omitempty"`
+	// ClusterStability informs openshift-tests whether this entire test suite is expected to be disruptive or not
+	// to normal cluster operations.
+	ClusterStability ClusterStability `json:"clusterStability,omitempty"`
+	// TestTimeout is the default timeout for tests in this suite.
+	TestTimeout *time.Duration `json:"testTimeout,omitempty"`
 }
 
 type Image struct {


### PR DESCRIPTION
In order to port suite evalation from OTE's CEL expr's, we also need to store the other options (count, parallelism, cluster stability, and timeouts) for the entire suite.

Ported from https://github.com/openshift/origin/blob/f06677b22d7184a445a41fc60a01707d87037b9a/pkg/test/ginkgo/test_suite.go#L146-L162

Note: children who define these parameters will have them superseded by the parent when executing in the parents' context.