### PR TITLE
Add Cypress test utility for converting metadata to test specs

### DIFF
--- a/pkg/cypress/util.go
+++ b/pkg/cypress/util.go
@@ -41,7 +41,6 @@ type TestSuites struct {
 
 // BuildExtensionTestSpecsFromCypressMetadata loads test metadata from JSON bytes
 // and creates ExtensionTestSpecs for each test case
-// declare metadata variable with //go:embed cypress-test-metadata.json in extension implementation
 func BuildExtensionTestSpecsFromCypressMetadata(metadata []byte) (ext.ExtensionTestSpecs, error) {
 	var testCases []TestCase
 	if err := json.Unmarshal(metadata, &testCases); err != nil {


### PR DESCRIPTION
Proposal of Cypress based webUI tests migration. design is like below

![image](https://github.com/user-attachments/assets/93263b86-9ff9-40fc-abea-60449d45520a)

Implement utility functions in pkg/cypress/util.go to:
- Parse Cypress test metadata from JSON files
- Convert test cases to ExtensionTestSpec format
- Execute individual Cypress tests and capture results
- Support test execution with environment variables
- Test metadata generation please refer to https://github.com/openshift/openshift-tests-private/pull/25557

This enables integration of Cypress tests into the OTE framework by providing the necessary conversion and execution logic. The utility handles test metadata parsing, test execution via Cypress CLI, and result reporting in the expected format.

In extension implementation we can build cypress test specs like below
```go
import (
	_ "embed"
	c "github.com/openshift-eng/openshift-tests-extension/pkg/cypress"
)

//go:embed cypress-test-metadata.json
var cypressMetadata []byte

func main() {
	...
	ext := e.NewExtension("openshift", "payload", "webui-tests")
	...
	cypressTestSpecs, err := c.BuildExtensionTestSpecsFromCypressMetadata(cypressMetadata)
	if err != nil {
		panic(fmt.Sprintf("could not build extension test specs from cypress test metadata: %+v", err.Error()))
	}
	...
	ext.AddSpecs(cypressTestSpecs)
}
```
To execute the cypress tests need to declare os env var `TEST_ROOT_DIR` to indicate root dir of test files. then we can get absolute path for test file. we need to another script to install dependencies as well. finally the OTE binary can execute the test like below
```bash
./example-tests run-test "features for get started resources (OCP-73109,yanpzhan,UserInterface) Update Explore new features and capabilities on Geting started resources card"
[
  {
    "name": "features for get started resources (OCP-73109,yanpzhan,UserInterface) Update Explore new features and capabilities on Geting started resources card",
    "lifecycle": "",
    "duration": 52464,
    "startTime": "2025-06-20 08:46:29.025889 UTC",
    "endTime": "2025-06-20 08:47:21.490770 UTC",
    "result": "passed",
    "output": "\nDevTools listening on ws://127.0.0.1:53917/devtools/browser/c1284d8b-451c-41c2-bfcd-beaac3f01fc6\n@cypress/grep: tests with \"OCP-73109\" in their names\n@cypress/grep: filtering specs using \"OCP-73109\" in the title\nCouldn't determine Mocha version\n\n====================================================================================================\n\n  (Run Starting)\n\n  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐\n  │ Cypress:        12.17.4                                                                        │\n  │ Browser:        Electron 106 (headless)                                                        │\n  │ Node Version:   v22.8.0 (/opt/homebrew/Cellar/node/22.8.0/bin/node)                            │\n  │ Specs:          1 found (get-started.cy.ts)                                                    │\n  │ Searched:       tests/overview/get-started.cy.ts                                               │\n  │ Experiments:    experimentalMemoryManagement=true,experimentalModifyObstructiveThirdPartyCode… │\n  └────────────────────────────────────────────────────────────────────────────────────────────────┘\n\n\n────────────────────────────────────────────────────────────────────────────────────────────────────\n                                                                                                    \n  Running:  get-started.cy.ts                                                               (1 of 1)\nCouldn't determine Mocha version\n\n\n  features for get started resources\n      Run admin command: oc adm policy add-cluster-role-to-user cluster-admin kubeadmin\n      operator name: Red Hat OpenShift AI\n      operator name: OpenShift Lightspeed Operator\n    ✓ (OCP-73109,yanpzhan,UserInterface) Update \"Explore new features and capabilities\" on \"Geting started resources\" card (43748ms)\n    - (OCP-73803,yapei,UserInterface)Add user-impersonation to QuickStart and new langs to ExploreAdminFeatures\n      Run admin command: oc adm policy remove-cluster-role-from-user cluster-admin kubeadmin\n\n\n  1 passing (45s)\n  1 pending\n\n[mochawesome] Report JSON saved to /Users/rio.liu/coderepo/openshift-tests-private/frontend/gui_test_screenshots/cypress_report_017.json\n\n\n  (Results)\n\n  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐\n  │ Tests:        2                                                                                │\n  │ Passing:      1                                                                                │\n  │ Failing:      0                                                                                │\n  │ Pending:      1                                                                                │\n  │ Skipped:      0                                                                                │\n  │ Screenshots:  0                                                                                │\n  │ Video:        false                                                                            │\n  │ Duration:     45 seconds                                                                       │\n  │ Spec Ran:     get-started.cy.ts                                                                │\n  └────────────────────────────────────────────────────────────────────────────────────────────────┘\n\n\n====================================================================================================\n\n  (Run Finished)\n\n\n       Spec                                              Tests  Passing  Failing  Pending  Skipped  \n  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐\n  │ ✔  get-started.cy.ts                        00:45        2        1        -        1        - │\n  └────────────────────────────────────────────────────────────────────────────────────────────────┘\n    ✔  All specs passed!                        00:45        2        1        -        1        -  \n\n"
  }
]
```

