### PR TITLE
add qualifier of component id for component suite

### DIFF
--- a/pkg/extension/extension.go
+++ b/pkg/extension/extension.go
@@ -117,9 +117,15 @@ func (e *Extension) AddGlobalSuite(suite Suite) *Extension {
 // in its own extension.
 func (e *Extension) AddSuite(suite Suite) *Extension {
 	expr := fmt.Sprintf("source == %q", e.Component.Identifier())
-	for i := range suite.Qualifiers {
-		suite.Qualifiers[i] = fmt.Sprintf("(%s) && (%s)", expr, suite.Qualifiers[i])
+	if len(suite.Qualifiers) == 0 {
+		suite.Qualifiers = []string{expr}
+	} else {
+		for i := range suite.Qualifiers {
+			suite.Qualifiers[i] = fmt.Sprintf("(%s) && (%s)",
+				expr, suite.Qualifiers[i])
+		}
 	}
+
 	e.AddGlobalSuite(suite)
 	return e
 }


### PR DESCRIPTION

when we define the component suite (not global suite) without qualifier, the default filter `source == ` is not added to the suite. it causes when we run this suite, it will not select the component case and select all case from all component. actually it is treated as global suite.

for example, we define component suite
```go
	ext.AddSuite(e.Suite{
		Name: "olmv1/all",
	})
```
when we run `./openshift-tests run olmv1/all --dry-run`, we expect only olmv1 case are selected, but actually all component case are select.

so, I try to enhance it.

Thanks