### PR TITLE
Wire the ginkgo logr to the same writer during ginkgo setup

### DIFF
--- a/pkg/ginkgo/logging.go
+++ b/pkg/ginkgo/logging.go
@@ -1,0 +1,21 @@
+package ginkgo
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/onsi/ginkgo/v2"
+)
+
+// this is copied from ginkgo because ginkgo made it internal and then hardcoded an init block
+// using these functions to wire to os.stdout and we want to wire to stderr (or a different buffer) so we can
+// have json output.
+
+func GinkgoLogrFunc(writer ginkgo.GinkgoWriterInterface) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		if prefix == "" {
+			writer.Printf("%s\n", args)
+		} else {
+			writer.Printf("%s %s\n", prefix, args)
+		}
+	}, funcr.Options{})
+}

--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -74,7 +74,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	}
 
 	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
-	fmt.Fprintf(stderr, "Deserializaion Erroer: %v\n", parseErr)
+	fmt.Fprintf(stderr, "Deserializaion Error: %v\n", parseErr)
 	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
 }
 

--- a/pkg/ginkgo/util.go
+++ b/pkg/ginkgo/util.go
@@ -36,6 +36,7 @@ func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
 
 	// Write output to Stderr
 	ginkgo.GinkgoWriter = ginkgo.NewWriter(os.Stderr)
+	ginkgo.GinkgoLogr = GinkgoLogrFunc(ginkgo.GinkgoWriter)
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
 

--- a/test/framework/info.go
+++ b/test/framework/info.go
@@ -40,4 +40,8 @@ var _ = Describe("[sig-testing] example-tests info", Label("framework"), func() 
 		Expect(result.Component.Kind).To(Equal("payload"), "Expected type to be 'payload'")
 		Expect(result.Component.Name).To(Equal("example-tests"), "Expected name to be 'default'")
 	})
+
+	It("should be able to log information", func() {
+		GinkgoLogr.Info("creating resource group", "resourceGroup", "resourceGroupName")
+	})
 })


### PR DESCRIPTION
This required copying a function that is in an internal package, but it's a small function that I didn't feel bad about doing it for.

I added a test demonstrating the problem and the fix.