### PR TITLE
Wire Suite.TestTimeout through to per-test parallel execution

### DIFF
--- a/pkg/cmd/cmdrun/runsuite.go
+++ b/pkg/cmd/cmdrun/runsuite.go
@@ -114,6 +114,14 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 				return errors.Wrap(err, "couldn't filter specs")
 			}
 
+			if suite.TestTimeout != nil {
+				for _, spec := range specs {
+					if spec.Timeout == 0 {
+						spec.Timeout = *suite.TestTimeout
+					}
+				}
+			}
+
 			concurrency := opts.concurrencyFlags.MaxConcurency
 			if suite.Parallelism > 0 {
 				concurrency = min(concurrency, suite.Parallelism)

--- a/pkg/extension/extensiontests/types.go
+++ b/pkg/extension/extensiontests/types.go
@@ -2,6 +2,7 @@ package extensiontests
 
 import (
 	"context"
+	"time"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
@@ -58,6 +59,10 @@ type ExtensionTestSpec struct {
 	// RunParallel invokes a test in parallel with other tests.  This is usually done by exec-ing out
 	// to the `ote-binary run-test "test name"` commmand and interpretting the result.
 	RunParallel func(ctx context.Context) *ExtensionTestResult `json:"-"`
+
+	// Timeout is the maximum duration for this test. If set, it overrides the default 90-minute
+	// timeout used by SpawnProcessToRunTest. This is typically populated from Suite.TestTimeout.
+	Timeout time.Duration `json:"-"`
 
 	// Hook functions
 	afterAll   []*OneTimeTask

--- a/pkg/ginkgo/util.go
+++ b/pkg/ginkgo/util.go
@@ -143,10 +143,13 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 
 				return result
 			},
-			RunParallel: func(ctx context.Context) *ext.ExtensionTestResult {
-				// TODO pass through timeout and determine Lifecycle
-				return SpawnProcessToRunTest(ctx, name, 90*time.Minute)
-			},
+		}
+		testCase.RunParallel = func(ctx context.Context) *ext.ExtensionTestResult {
+			timeout := 90 * time.Minute
+			if testCase.Timeout > 0 {
+				timeout = testCase.Timeout
+			}
+			return SpawnProcessToRunTest(ctx, name, timeout)
 		}
 		specs = append(specs, testCase)
 	})


### PR DESCRIPTION
## What

Wire `Suite.TestTimeout` through to per-test parallel execution, replacing the hardcoded 90-minute timeout in `SpawnProcessToRunTest`.

## Why

The `Suite.TestTimeout` field was defined in the `Suite` struct but never used (there's a `TODO` at [util.go:147](https://github.com/openshift-eng/openshift-tests-extension/blob/0fed2b824818/pkg/ginkgo/util.go#L147)). The hardcoded 90-minute timeout is insufficient for suites with many tests competing for shared resources (e.g., leased identity containers), where some tests must wait significant time before starting execution.

This enables downstream consumers to configure per-suite timeouts. For example, ARO-HCP's prod e2e suite needs a longer timeout because a multi-container test waits over an hour for lease assignment before it can begin running.

## Changes

- **`pkg/extension/extensiontests/types.go`**: Add `Timeout` field to `ExtensionTestSpec`
- **`pkg/ginkgo/util.go`**: Use `spec.Timeout` in `RunParallel` closure, falling back to 90m default
- **`pkg/cmd/cmdrun/runsuite.go`**: Propagate `Suite.TestTimeout` to each spec's `Timeout` field before execution

Fully backward compatible — suites without `TestTimeout` continue using the 90-minute default.
