### PR TITLE
Add --progress flag to show real-time test execution

### DIFF
--- a/pkg/cmd/cmdrun/runsuite.go
+++ b/pkg/cmd/cmdrun/runsuite.go
@@ -25,12 +25,14 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 		concurrencyFlags *flags.ConcurrencyFlags
 		junitPath        string
 		htmlPath         string
+		progress         bool
 	}{
 		componentFlags:   flags.NewComponentFlags(),
 		outputFlags:      flags.NewOutputFlags(),
 		concurrencyFlags: flags.NewConcurrencyFlags(),
 		junitPath:        "",
 		htmlPath:         "",
+		progress:         false,
 	}
 
 	cmd := &cobra.Command{
@@ -39,6 +41,11 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 			"development use. Orchestration parameters, scheduling, isolation, etc are not obeyed, and Ginkgo tests are executed serially.",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Set environment variable for progress reporting if flag is set
+			if opts.progress {
+				os.Setenv("OTE_PROGRESS", "true")
+			}
+
 			ctx, cancelCause := context.WithCancelCause(context.Background())
 			defer cancelCause(errors.New("exiting"))
 
@@ -141,6 +148,7 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 	opts.concurrencyFlags.BindFlags(cmd.Flags())
 	cmd.Flags().StringVarP(&opts.junitPath, "junit-path", "j", opts.junitPath, "write results to junit XML")
 	cmd.Flags().StringVar(&opts.htmlPath, "html-path", opts.htmlPath, "write results to summary HTML")
+	cmd.Flags().BoolVar(&opts.progress, "progress", opts.progress, "show progress reporting during test execution (displays STEP output in real-time)")
 
 	return cmd
 }

--- a/pkg/cmd/cmdrun/runtest.go
+++ b/pkg/cmd/cmdrun/runtest.go
@@ -23,11 +23,13 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 		concurrencyFlags *flags.ConcurrencyFlags
 		nameFlags        *flags.NamesFlags
 		outputFlags      *flags.OutputFlags
+		progress         bool
 	}{
 		componentFlags:   flags.NewComponentFlags(),
 		nameFlags:        flags.NewNamesFlags(),
 		outputFlags:      flags.NewOutputFlags(),
 		concurrencyFlags: flags.NewConcurrencyFlags(),
+		progress:         false,
 	}
 
 	cmd := &cobra.Command{
@@ -35,6 +37,11 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 		Short:        "Runs tests by name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Set environment variable for progress reporting if flag is set
+			if opts.progress {
+				os.Setenv("OTE_PROGRESS", "true")
+			}
+
 			ctx, cancelCause := context.WithCancelCause(context.Background())
 			defer cancelCause(errors.New("exiting"))
 
@@ -108,6 +115,7 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 	opts.nameFlags.BindFlags(cmd.Flags())
 	opts.outputFlags.BindFlags(cmd.Flags())
 	opts.concurrencyFlags.BindFlags(cmd.Flags())
+	cmd.Flags().BoolVar(&opts.progress, "progress", opts.progress, "show progress reporting during test execution (displays STEP output in real-time)")
 
 	return cmd
 }

--- a/pkg/ginkgo/util.go
+++ b/pkg/ginkgo/util.go
@@ -19,6 +19,10 @@ import (
 )
 
 func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
+	return configureGinkgoWithProgress(false)
+}
+
+func configureGinkgoWithProgress(showProgress bool) (*types.SuiteConfig, *types.ReporterConfig, error) {
 	if !ginkgo.GetSuite().InPhaseBuildTree() {
 		if err := ginkgo.GetSuite().BuildTree(); err != nil {
 			return nil, nil, errors.Wrapf(err, "couldn't build ginkgo tree")
@@ -32,6 +36,13 @@ func configureGinkgo() (*types.SuiteConfig, *types.ReporterConfig, error) {
 	suiteConfig.Timeout = 24 * time.Hour
 	reporterConfig.NoColor = true
 	reporterConfig.Verbose = true
+
+	// Enable progress reporting if requested via --progress flag or OTE_PROGRESS env var
+	// This shows STEP output as tests run, not just when they complete
+	if showProgress || os.Getenv("OTE_PROGRESS") == "true" {
+		reporterConfig.ShowNodeEvents = true
+	}
+
 	ginkgo.SetReporterConfig(reporterConfig)
 
 	// Write output to Stderr


### PR DESCRIPTION
This commit adds support for Ginkgo's progress reporting feature by exposing a --progress flag in both run-suite and run-test commands.

Changes:
- Added --progress flag to run-suite command
- Added --progress flag to run-test command
- Modified Ginkgo configuration to enable ShowNodeEvents when progress is requested
- Progress can also be enabled via OTE_PROGRESS=true environment variable

When --progress is enabled, users will see STEP output in real-time as tests execute, rather than only seeing output after tests complete.

This significantly improves the local development experience for long-running tests (e.g., operator installation, upgrade tests).

Example usage:
  ./bin/test-binary run-suite my/suite --progress
  ./bin/test-binary run-test -n "test name" --progress

Closes: https://github.com/openshift-eng/openshift-tests-extension/issues

Generated-by: Claude