### PR TITLE
Propagate test timeout into subprocess context

### DIFF
--- a/pkg/cmd/cmdrun/runtest.go
+++ b/pkg/cmd/cmdrun/runtest.go
@@ -23,6 +23,7 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 		concurrencyFlags *flags.ConcurrencyFlags
 		nameFlags        *flags.NamesFlags
 		outputFlags      *flags.OutputFlags
+		timeout          time.Duration
 	}{
 		componentFlags:   flags.NewComponentFlags(),
 		nameFlags:        flags.NewNamesFlags(),
@@ -37,6 +38,11 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancelCause := context.WithCancelCause(context.Background())
 			defer cancelCause(errors.New("exiting"))
+			if opts.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, opts.timeout)
+				defer cancel()
+			}
 
 			abortCh := make(chan os.Signal, 2)
 			go func() {
@@ -104,6 +110,7 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().DurationVar(&opts.timeout, "timeout", 0, "Maximum duration for the test. When set, the test context will have a deadline, causing blocking operations like PollUntilDone to fail cleanly instead of hanging until the parent kills the process.")
 	opts.componentFlags.BindFlags(cmd.Flags())
 	opts.nameFlags.BindFlags(cmd.Flags())
 	opts.outputFlags.BindFlags(cmd.Flags())

--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -25,7 +25,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	command := exec.CommandContext(longerCtx, os.Args[0], "run-test", "--output=json", testName)
+	command := exec.CommandContext(longerCtx, os.Args[0], "run-test", "--output=json", fmt.Sprintf("--timeout=%s", timeout), testName)
 	command.Stdout = stdout
 	command.Stderr = stderr
 


### PR DESCRIPTION
SpawnProcessToRunTest has the per-test timeout but only uses it for signal scheduling in the parent. The subprocess creates context.Background() with no deadline, so any blocking call (e.g. PollUntilDone) hangs until the parent kills the process, producing "Deserializaion Error: no output from command".

Pass --timeout to the run-test subcommand and apply it as a context deadline in the subprocess. This gives every downstream call a bounded context, letting operations fail cleanly instead of requiring signal escalation and process kill.

Backward compatible: --timeout defaults to 0 (no deadline), preserving existing behavior for direct run-test invocations.