### PR TITLE
 Fix signal escalation race in SpawnProcessToRunTest

### DIFF
--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -19,8 +19,6 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	// longerCtx is used to backstop the process, but leave termination up to us if possible to allow a double interrupt
 	longerCtx, longerCancel := context.WithTimeout(ctx, timeout+15*time.Minute)
 	defer longerCancel()
-	timeoutCtx, shorterCancel := context.WithTimeout(longerCtx, timeout)
-	defer shorterCancel()
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -36,36 +34,29 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 		return newTestResult(testName, extensiontests.ResultFailed, start, time.Now(), stdout, stderr)
 	}
 
+	done := make(chan struct{})
 	go func() {
 		select {
-		// interrupt tests after timeout, and abort if they don't complete quick enough
 		case <-time.After(timeout):
-			if command.Process != nil {
-				// we're not going to do anything with the err
-				_ = command.Process.Signal(syscall.SIGINT)
-			}
-			// if the process appears to be hung a significant amount of time after the timeout
-			// send an ABRT so we get a stack dump
-			select {
-			case <-time.After(time.Minute):
-				if command.Process != nil {
-					// we're not going to do anything with the err
-					_ = command.Process.Signal(syscall.SIGABRT)
-				}
-			case <-timeoutCtx.Done():
-				if command.Process != nil {
-					_ = command.Process.Signal(syscall.SIGABRT)
-				}
-			}
-		case <-timeoutCtx.Done():
-			if command.Process != nil {
-				_ = command.Process.Signal(syscall.SIGINT)
-			}
+		case <-done:
+			return
+		}
+		if command.Process != nil {
+			_ = command.Process.Signal(syscall.SIGINT)
+		}
+		select {
+		case <-time.After(time.Minute):
+		case <-done:
+			return
+		}
+		if command.Process != nil {
+			_ = command.Process.Signal(syscall.SIGABRT)
 		}
 	}()
 
 	result := extensiontests.ResultFailed
 	cmdErr := command.Wait()
+	close(done)
 
 	subcommandResult, parseErr := newTestResultFromOutput(stdout)
 	if parseErr == nil {
@@ -74,7 +65,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	}
 
 	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
-	fmt.Fprintf(stderr, "Deserializaion Error: %v\n", parseErr)
+	fmt.Fprintf(stderr, "Deserialization Error: %v\n", parseErr)
 	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
 }
 


### PR DESCRIPTION
When a test subprocess times out, the runner sends SIGINT to let it write results, then SIGABRT after a grace period if the process is hung.

Neither worked: the goroutine used timeoutCtx with the same deadline as time.After(timeout), so timeoutCtx.Done() always won the select — sending SIGINT with no escalation path. Hung processes waited up to 15 minutes for longerCtx to kill them.

Replace timeoutCtx with a done channel closed after Wait() returns.

One path: timeout, SIGINT, grace period, SIGABRT, with early exit when the process exits on its own.

https://redhat.atlassian.net/browse/ARO-25369

I pushed just the tests first against the old code to verify:
https://github.com/openshift-eng/openshift-tests-extension/pull/65#issuecomment-4549797188