### PR TITLE
Fix signal escalation in SpawnProcessToRunTest

### DIFF
--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -37,30 +37,22 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	}
 
 	go func() {
+		// interrupt after timeout, or exit early if the process finishes first
 		select {
-		// interrupt tests after timeout, and abort if they don't complete quick enough
 		case <-time.After(timeout):
-			if command.Process != nil {
-				// we're not going to do anything with the err
-				_ = command.Process.Signal(syscall.SIGINT)
-			}
-			// if the process appears to be hung a significant amount of time after the timeout
-			// send an ABRT so we get a stack dump
-			select {
-			case <-time.After(time.Minute):
-				if command.Process != nil {
-					// we're not going to do anything with the err
-					_ = command.Process.Signal(syscall.SIGABRT)
-				}
-			case <-timeoutCtx.Done():
-				if command.Process != nil {
-					_ = command.Process.Signal(syscall.SIGABRT)
-				}
-			}
 		case <-timeoutCtx.Done():
-			if command.Process != nil {
-				_ = command.Process.Signal(syscall.SIGINT)
-			}
+		}
+		if command.Process != nil {
+			_ = command.Process.Signal(syscall.SIGINT)
+		}
+		// Canceled means the process exited and the context was cancelled — no need to escalate
+		if timeoutCtx.Err() == context.Canceled {
+			return
+		}
+		// if the process is hung, send SIGABRT after a grace period for a stack dump
+		<-time.After(time.Minute)
+		if command.Process != nil {
+			_ = command.Process.Signal(syscall.SIGABRT)
 		}
 	}()
 
@@ -74,7 +66,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	}
 
 	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
-	fmt.Fprintf(stderr, "Deserializaion Error: %v\n", parseErr)
+	fmt.Fprintf(stderr, "Deserialization Error: %v\n", parseErr)
 	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
 }
 


### PR DESCRIPTION
Fix the SIGINT to SIGABRT escalation in the test subprocess signal handler.

When a test subprocess times out, the runner sends SIGINT to let it write results, then SIGABRT after a grace period if the process is hung.

In practice, the SIGABRT escalation never really works — the timeout context nearly always fires before the escalation timer because it gets created before a subprocess launches, so SIGABRT is either skipped entirely or fired immediately after SIGINT with no grace period. Hung subprocesses waited up to 15 minutes to be killed, producing deserialization errors instead of useful diagnostic output.

Also fix typo: Deserializaion to Deserialization.