### PR TITLE
Fix incorrect EndTime in fallback test result

### DIFF
--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -96,7 +96,7 @@ func newTestResultFromOutput(stdout *bytes.Buffer) (*extensiontests.ExtensionTes
 func newTestResult(name string, result extensiontests.Result, start, end time.Time, stdout, stderr *bytes.Buffer) *extensiontests.ExtensionTestResult {
 	duration := end.Sub(start)
 	dbStart := dbtime.DBTime(start)
-	dbEnd := dbtime.DBTime(start)
+	dbEnd := dbtime.DBTime(end)
 	ret := &extensiontests.ExtensionTestResult{
 		Name:      name,
 		Lifecycle: "", // lifecycle is completed one level above this.


### PR DESCRIPTION
newTestResult used start instead of end for dbEnd, causing the fallback result (when subprocess output can't be parsed) to report a wrong EndTime.

Example: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-Azure-ARO-HCP-main-periodic-integration-e2e-parallel/2034172422873157632

```
  "name": "Customer should be able to create several HCP clusters in their customer
  resource group..."
  "duration": 6300004429896,
  "startTime": "2026-03-18 07:48:44.137514 UTC",
  "endTime": "2026-03-18 07:48:44.137514 UTC",
  "result": "failed",
```