### PR TITLE
Remove redundant timeout timer in signal escalation goroutine

### DIFF
--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -37,11 +37,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	}
 
 	go func() {
-		// interrupt after timeout, or exit early if the process finishes first
-		select {
-		case <-time.After(timeout):
-		case <-timeoutCtx.Done():
-		}
+		<-timeoutCtx.Done()
 		if command.Process != nil {
 			_ = command.Process.Signal(syscall.SIGINT)
 		}


### PR DESCRIPTION
The context already handles the timeout, making the standalone timer dead code that left an orphaned timer allocated for the full test duration on every normally-completing test.