### PR TITLE
DPTP-4943: Fix panic when running Pending ginkgo specs

### DIFF
--- a/pkg/ginkgo/util.go
+++ b/pkg/ginkgo/util.go
@@ -80,22 +80,17 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 					Name: spec.Text(),
 				}
 
-				var summary types.SpecReport
 				ginkgo.GetSuite().RunSpec(spec, ginkgo.Labels{}, "", cwd, ginkgo.GetFailer(), ginkgo.GetWriter(), *suiteConfig,
 					*reporterConfig)
-				for _, report := range ginkgo.GetSuite().GetReport().SpecReports {
-					if report.NumAttempts > 0 {
-						summary = report
-					}
-				}
+				summary := findSpecReport(ginkgo.GetSuite().GetReport().SpecReports)
 
 				result.Output = summary.CapturedGinkgoWriterOutput
 				result.Error = summary.CapturedStdOutErr
 
-				switch {
-				case summary.State == types.SpecStatePassed:
+				switch summary.State {
+				case types.SpecStatePassed:
 					result.Result = ext.ResultPassed
-				case summary.State == types.SpecStateSkipped, summary.State == types.SpecStatePending:
+				case types.SpecStateSkipped, types.SpecStatePending:
 					result.Result = ext.ResultSkipped
 					if len(summary.Failure.Message) > 0 {
 						result.Output = fmt.Sprintf(
@@ -114,7 +109,7 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 							summary.Failure.ForwardedPanic,
 						)
 					}
-				case summary.State == types.SpecStateFailed, summary.State == types.SpecStatePanicked, summary.State == types.SpecStateInterrupted, summary.State == types.SpecStateAborted:
+				case types.SpecStateFailed, types.SpecStatePanicked, types.SpecStateInterrupted, types.SpecStateAborted:
 					result.Result = ext.ResultFailed
 					var errors []string
 					if len(summary.Failure.ForwardedPanic) > 0 {
@@ -125,7 +120,7 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 					}
 					errors = append(errors, fmt.Sprintf("fail [%s:%d]: %s", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message))
 					result.Error = strings.Join(errors, "\n")
-				case summary.State == types.SpecStateTimedout:
+				case types.SpecStateTimedout:
 					result.Result = ext.ResultFailed
 					var errors []string
 					for _, additionalFailure := range summary.AdditionalFailures {
@@ -136,8 +131,12 @@ func BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns ...ext.SelectFunc
 					}
 					errors = append(errors, fmt.Sprintf("fail [%s:%d]: %s", lastFilenameSegment(summary.Failure.Location.FileName), summary.Failure.Location.LineNumber, summary.Failure.Message))
 					result.Error = strings.Join(errors, "\n")
+				case types.SpecStateInvalid:
+					result.Result = ext.ResultFailed
+					result.Error = fmt.Sprintf("test produced no spec report; this is a bug in the test framework: %#v", summary)
 				default:
-					panic(fmt.Sprintf("test produced unknown outcome: %#v", summary))
+					result.Result = ext.ResultFailed
+					result.Error = fmt.Sprintf("test produced unknown outcome: %#v", summary)
 				}
 
 				return result
@@ -210,6 +209,25 @@ func lastFilenameSegment(filename string) string {
 		return parts[len(parts)-1]
 	}
 	return filename
+}
+
+// findSpecReport selects the best matching spec report from the list of reports
+// produced by RunSpec. It first looks for a report that was actually attempted
+// (NumAttempts > 0), which covers passed/failed/panicked specs. If none is found
+// (as happens with Pending or Skipped specs where Ginkgo never enters the
+// execution loop), it falls back to the last report in the list.
+func findSpecReport(reports types.SpecReports) types.SpecReport {
+	var summary types.SpecReport
+	for _, report := range reports {
+		if report.NumAttempts > 0 {
+			summary = report
+		}
+	}
+	// Pending/Skipped specs have NumAttempts==0; fall back to the last report
+	if summary.State == types.SpecStateInvalid && len(reports) > 0 {
+		summary = reports[len(reports)-1]
+	}
+	return summary
 }
 
 func collectAdditionalFailures(errors *[]string, suffix string, failure types.Failure) {

--- a/pkg/ginkgo/util_test.go
+++ b/pkg/ginkgo/util_test.go
@@ -1,0 +1,98 @@
+package ginkgo
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func TestFindSpecReport(t *testing.T) {
+	tests := []struct {
+		name          string
+		reports       types.SpecReports
+		expectedState types.SpecState
+	}{
+		{
+			name:          "empty reports returns zero-valued report",
+			reports:       types.SpecReports{},
+			expectedState: types.SpecStateInvalid,
+		},
+		{
+			name: "passed spec with NumAttempts > 0",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStatePassed,
+					NumAttempts: 1,
+				},
+			},
+			expectedState: types.SpecStatePassed,
+		},
+		{
+			name: "failed spec with NumAttempts > 0",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStateFailed,
+					NumAttempts: 2,
+				},
+			},
+			expectedState: types.SpecStateFailed,
+		},
+		{
+			name: "pending spec has NumAttempts 0 - falls back to last report",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStatePending,
+					NumAttempts: 0,
+				},
+			},
+			expectedState: types.SpecStatePending,
+		},
+		{
+			name: "skipped spec has NumAttempts 0 - falls back to last report",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStateSkipped,
+					NumAttempts: 0,
+				},
+			},
+			expectedState: types.SpecStateSkipped,
+		},
+		{
+			name: "multiple reports picks attempted one over pending",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStatePending,
+					NumAttempts: 0,
+				},
+				{
+					State:       types.SpecStatePassed,
+					NumAttempts: 1,
+				},
+			},
+			expectedState: types.SpecStatePassed,
+		},
+		{
+			name: "multiple attempted reports picks last attempted",
+			reports: types.SpecReports{
+				{
+					State:       types.SpecStatePassed,
+					NumAttempts: 1,
+				},
+				{
+					State:       types.SpecStateFailed,
+					NumAttempts: 1,
+				},
+			},
+			expectedState: types.SpecStateFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findSpecReport(tt.reports)
+			if result.State != tt.expectedState {
+				t.Errorf("findSpecReport() state = %v, want %v", result.State, tt.expectedState)
+			}
+		})
+	}
+}

--- a/test/example/example.go
+++ b/test/example/example.go
@@ -55,4 +55,9 @@ var _ = Describe("[sig-testing] openshift-tests-extension", func() {
 	It("should support test-skips via environment flags", func() {
 		Expect(true).To(BeTrue()) //This doesn't need to do anything special, just exist
 	})
+
+	XIt("should support pending tests", func() {
+		// This test is pending (XIt) and should be reported as skipped, not panic.
+		Expect(true).To(BeTrue())
+	})
 })

--- a/test/framework/run.go
+++ b/test/framework/run.go
@@ -56,6 +56,17 @@ var _ = Describe("[sig-testing] example-tests run-suite", Label("framework"), fu
 		}
 	})
 
+	It("should contain a test that was skipped due to pending", func() {
+		var foundPending bool
+		for _, test := range result {
+			if test.Name == "[sig-testing] openshift-tests-extension should support pending tests" && test.Result == "skipped" {
+				foundPending = true
+				break
+			}
+		}
+		Expect(foundPending).To(BeTrue(), "Expected pending test (XIt) to be reported as skipped")
+	})
+
 	It("fast suite should not have a slow test", func() {
 		foundTest := false
 		for _, test := range result {


### PR DESCRIPTION
Pending specs (e.g. via g.XIt) have NumAttempts == 0, so the report-finding loop never matched them, leaving a zero-valued summary that hit the default panic. Extract report selection into findSpecReport with a fallback for unexecuted specs, and replace the default panic with a failed result.

Co-authored-by: Pi(claude-opus-4-6) <noreply@anthropic.com>
