### PR TITLE
Add generic pool scheduling to OTE scheduler

### DIFF
--- a/pkg/cmd/cmdrun/runsuite.go
+++ b/pkg/cmd/cmdrun/runsuite.go
@@ -36,7 +36,7 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "run-suite NAME",
 		Short: "Run a group of tests by suite. This is more limited than origin, and intended for light local " +
-			"development use. Orchestration parameters, scheduling, isolation, etc are not obeyed, and Ginkgo tests are executed serially.",
+			"development use. Ginkgo tests are executed in parallel, controlled by --max-concurrency (default 10).",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancelCause := context.WithCancelCause(context.Background())
@@ -126,7 +126,11 @@ func NewRunSuiteCommand(registry *extension.Registry) *cobra.Command {
 			if suite.Parallelism > 0 {
 				concurrency = min(concurrency, suite.Parallelism)
 			}
-			results, runErr := specs.Run(ctx, compositeWriter, concurrency)
+			var runOpts []extensiontests.SchedulerOption
+			if len(suite.ResourcePools) > 0 {
+				runOpts = append(runOpts, extensiontests.WithResourcePoolCapacity(suite.ResourcePools))
+			}
+			results, runErr := specs.Run(ctx, compositeWriter, concurrency, runOpts...)
 			if opts.junitPath != "" {
 				// we want to commit the results to disk regardless of the success or failure of the specs
 				if err := writeResults(opts.junitPath, results); err != nil {

--- a/pkg/extension/extensiontests/scheduler.go
+++ b/pkg/extension/extensiontests/scheduler.go
@@ -2,6 +2,9 @@ package extensiontests
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"os"
 	"sync"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
@@ -9,8 +12,43 @@ import (
 
 const defaultConflictGroup = "default"
 
+// SchedulerOption configures optional scheduler behavior.
+type SchedulerOption func(*testScheduler)
+
+// WithResourcePoolCapacity configures named resource pools with finite capacity.
+// The scheduler will only dispatch a test when all of its declared pool demands
+// can be satisfied by currently available capacity.
+func WithResourcePoolCapacity(pools map[string]int) SchedulerOption {
+	return func(ts *testScheduler) {
+		ts.poolCapacity = maps.Clone(pools)
+		ts.poolAvailable = maps.Clone(pools)
+	}
+}
+
+// WithSchedulerAccessor registers a callback that receives the Scheduler during
+// construction, before NewScheduler returns. This allows callers that don't
+// directly create the scheduler (e.g., code invoking Run()) to store a reference
+// for external observability. The Scheduler is fully initialized when the callback
+// fires; type-assert to SchedulerDiagnostics to access GetSnapshot.
+func WithSchedulerAccessor(fn func(Scheduler)) SchedulerOption {
+	return func(ts *testScheduler) {
+		ts.accessor = fn
+	}
+}
+
+// SchedulerSnapshot is a point-in-time view of scheduler state for diagnostics.
+type SchedulerSnapshot struct {
+	QueueLength          int
+	QueueFront           string
+	QueueFrontResourcePools map[string]int
+	ResourcePoolCapacity    map[string]int
+	ResourcePoolAvailable   map[string]int
+	ActiveCount          int
+}
+
 // Scheduler defines the interface for test scheduling.
-// It manages scheduling based on isolation requirements (conflicts, taints, tolerations).
+// It manages scheduling based on isolation requirements (conflicts, taints, tolerations)
+// and optional named resource pool capacity.
 //
 // Callers must follow a get-once, complete-once protocol: every non-nil spec returned by
 // GetNextTestToRun must eventually be passed to MarkTestComplete exactly once, including
@@ -22,32 +60,113 @@ type Scheduler interface {
 	// This method can be safely called from multiple goroutines concurrently.
 	GetNextTestToRun(ctx context.Context) *ExtensionTestSpec
 
-	// MarkTestComplete marks a test as complete, cleaning up its conflicts and taints.
-	// This may unblock other tests that were waiting.
+	// MarkTestComplete marks a test as complete, cleaning up its conflicts, taints, and
+	// pool reservations. This may unblock other tests that were waiting.
 	// This method can be safely called from multiple goroutines concurrently.
 	MarkTestComplete(spec *ExtensionTestSpec)
 }
 
-// testScheduler manages test scheduling based on conflicts, taints, and tolerations.
-// It maintains an ordered queue of tests and provides thread-safe scheduling operations.
+// SchedulerDiagnostics provides observability into scheduler state.
+// The testScheduler implements this interface; callers can type-assert to access it.
+type SchedulerDiagnostics interface {
+	// GetSnapshot returns a point-in-time view of the scheduler's internal state
+	// for diagnostics and external observability (e.g., stall detection).
+	GetSnapshot() SchedulerSnapshot
+}
+
+// testScheduler manages test scheduling based on conflicts, taints, tolerations,
+// and named resource pool capacity. It maintains an ordered queue of tests and
+// provides thread-safe scheduling operations.
 type testScheduler struct {
 	mu               sync.Mutex
-	cond             *sync.Cond // condition variable to signal when tests complete
+	cond             *sync.Cond                 // condition variable to signal when tests complete
 	tests            []*ExtensionTestSpec
 	runningConflicts map[string]sets.Set[string] // tracks which conflicts are running per group: group -> set of conflicts
 	activeTaints     map[string]int              // tracks how many tests are currently applying each taint
+	poolCapacity     map[string]int              // total capacity per pool (nil if no pools configured)
+	poolAvailable    map[string]int              // currently available per pool
+	activeCount      int                         // tests dispatched but not yet completed
+	accessor         func(Scheduler)
 }
 
 // NewScheduler creates a test scheduler. It accepts tests in any order and schedules
-// them based on isolation requirements (conflicts, taints, tolerations).
-func NewScheduler(tests []*ExtensionTestSpec) Scheduler {
+// them based on isolation requirements (conflicts, taints, tolerations) and optional
+// pool capacity constraints. When pool capacity is configured via WithResourcePoolCapacity,
+// the constructor validates that no test demands more than the total pool capacity,
+// references only defined pools, and has non-negative demand.
+func NewScheduler(tests []*ExtensionTestSpec, opts ...SchedulerOption) (Scheduler, error) {
 	ts := &testScheduler{
 		tests:            append([]*ExtensionTestSpec(nil), tests...),
 		runningConflicts: make(map[string]sets.Set[string]),
 		activeTaints:     make(map[string]int),
 	}
 	ts.cond = sync.NewCond(&ts.mu)
-	return ts
+
+	for _, opt := range opts {
+		opt(ts)
+	}
+
+	if ts.poolCapacity != nil {
+		for pool, capacity := range ts.poolCapacity {
+			if capacity < 0 {
+				return nil, fmt.Errorf("pool %q has negative capacity (%d)", pool, capacity)
+			}
+		}
+		for _, t := range tests {
+			for pool, demand := range t.Resources.ResourcePools {
+				if demand < 0 {
+					return nil, fmt.Errorf("test %q has negative demand (%d) for pool %q", t.Name, demand, pool)
+				}
+				if demand == 0 {
+					fmt.Fprintf(os.Stderr, "[scheduler] WARNING: test %q declares zero demand for pool %q (likely misconfiguration)\n", t.Name, pool)
+				}
+				poolCap, ok := ts.poolCapacity[pool]
+				if !ok {
+					return nil, fmt.Errorf("test %q declares pool %q but no capacity defined for it", t.Name, pool)
+				}
+				if demand > poolCap {
+					return nil, fmt.Errorf("test %q demands %d units of pool %q but total capacity is %d",
+						t.Name, demand, pool, poolCap)
+				}
+			}
+		}
+	} else {
+		for _, t := range tests {
+			if len(t.Resources.ResourcePools) > 0 {
+				fmt.Fprintf(os.Stderr, "[scheduler] WARNING: test %q declares resource pool demands but no pool capacity is configured\n", t.Name)
+				break
+			}
+		}
+	}
+
+	if ts.accessor != nil {
+		ts.accessor(ts)
+	}
+
+	return ts, nil
+}
+
+// GetSnapshot returns a point-in-time snapshot of the scheduler's internal state.
+func (ts *testScheduler) GetSnapshot() SchedulerSnapshot {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	snap := SchedulerSnapshot{
+		QueueLength: len(ts.tests),
+		ActiveCount: ts.activeCount,
+	}
+
+	if len(ts.tests) > 0 {
+		snap.QueueFront = ts.tests[0].Name
+		snap.QueueFrontResourcePools = maps.Clone(ts.tests[0].Resources.ResourcePools)
+	}
+
+	if ts.poolCapacity != nil {
+		snap.ResourcePoolCapacity = maps.Clone(ts.poolCapacity)
+		snap.ResourcePoolAvailable = maps.Clone(ts.poolAvailable)
+	}
+
+	return snap
 }
 
 // GetNextTestToRun blocks until a test is available to run, or returns nil
@@ -98,7 +217,10 @@ func (ts *testScheduler) GetNextTestToRun(ctx context.Context) *ExtensionTestSpe
 			// Check if test can tolerate all currently active taints
 			canTolerate := ts.canTolerateTaints(spec)
 
-			if !hasConflict && canTolerate {
+			// Check if pool capacity is available for this test
+			hasCapacity := ts.hasPoolCapacity(spec)
+
+			if !hasConflict && canTolerate && hasCapacity {
 				isolation := &spec.Resources.Isolation
 
 				// Found a runnable test - ATOMICALLY:
@@ -112,10 +234,23 @@ func (ts *testScheduler) GetNextTestToRun(ctx context.Context) *ExtensionTestSpe
 					ts.activeTaints[taint]++
 				}
 
-				// 3. Remove test from queue
+				// 3. Decrement pool availability and log transitions
+				if ts.poolCapacity != nil {
+					for pool, demand := range spec.Resources.ResourcePools {
+						before := ts.poolAvailable[pool]
+						ts.poolAvailable[pool] -= demand
+						fmt.Fprintf(os.Stderr, "[scheduler] dispatch %s (pool %s: %d->%d/%d available)\n",
+							spec.Name, pool, before, ts.poolAvailable[pool], ts.poolCapacity[pool])
+					}
+				}
+
+				// 4. Track active count
+				ts.activeCount++
+
+				// 5. Remove test from queue
 				ts.tests = append(ts.tests[:i], ts.tests[i+1:]...)
 
-				// 4. Return the test (now safe to run)
+				// 6. Return the test (now safe to run)
 				return spec
 			}
 		}
@@ -163,8 +298,21 @@ func (ts *testScheduler) canTolerateTaints(spec *ExtensionTestSpec) bool {
 	return true
 }
 
-// MarkTestComplete marks all conflicts and taints of a spec as no longer running/active
-// and signals waiting workers that blocked tests may now be runnable.
+// hasPoolCapacity checks if the scheduler has enough capacity in all pools for the spec.
+func (ts *testScheduler) hasPoolCapacity(spec *ExtensionTestSpec) bool {
+	if ts.poolCapacity == nil || len(spec.Resources.ResourcePools) == 0 {
+		return true
+	}
+	for pool, demand := range spec.Resources.ResourcePools {
+		if ts.poolAvailable[pool] < demand {
+			return false
+		}
+	}
+	return true
+}
+
+// MarkTestComplete marks all conflicts, taints, and pool reservations of a spec as
+// no longer running/active and signals waiting workers that blocked tests may now be runnable.
 // This should be called after a test completes execution.
 func (ts *testScheduler) MarkTestComplete(spec *ExtensionTestSpec) {
 	ts.mu.Lock()
@@ -191,6 +339,26 @@ func (ts *testScheduler) MarkTestComplete(spec *ExtensionTestSpec) {
 		if ts.activeTaints[taint] <= 0 {
 			delete(ts.activeTaints, taint)
 		}
+	}
+
+	// Return pool units and log transitions
+	if ts.poolCapacity != nil {
+		for pool, demand := range spec.Resources.ResourcePools {
+			before := ts.poolAvailable[pool]
+			ts.poolAvailable[pool] += demand
+			if ts.poolAvailable[pool] > ts.poolCapacity[pool] {
+				fmt.Fprintf(os.Stderr, "[scheduler] WARNING: pool %q overflow: available %d > capacity %d, capping\n",
+					pool, ts.poolAvailable[pool], ts.poolCapacity[pool])
+				ts.poolAvailable[pool] = ts.poolCapacity[pool]
+			}
+			fmt.Fprintf(os.Stderr, "[scheduler] complete %s (pool %s: %d->%d/%d available)\n",
+				spec.Name, pool, before, ts.poolAvailable[pool], ts.poolCapacity[pool])
+		}
+	}
+
+	// Track active count
+	if ts.activeCount > 0 {
+		ts.activeCount--
 	}
 
 	// Signal waiting workers that the state has changed

--- a/pkg/extension/extensiontests/scheduler_test.go
+++ b/pkg/extension/extensiontests/scheduler_test.go
@@ -2,6 +2,9 @@ package extensiontests
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,15 +18,34 @@ const (
 const (
 	conflictDatabase = "database"
 	conflictNetwork  = "network"
-	conflictBlocker = "blocker"
-	taintGPU        = "gpu"
+	conflictBlocker  = "blocker"
+	taintGPU         = "gpu"
 )
+
+func mustNewScheduler(t *testing.T, tests []*ExtensionTestSpec, opts ...SchedulerOption) Scheduler {
+	t.Helper()
+	s, err := NewScheduler(tests, opts...)
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+	return s
+}
 
 func newTestSpec(name string, isolation Isolation) *ExtensionTestSpec {
 	return &ExtensionTestSpec{
 		Name: name,
 		Resources: Resources{
 			Isolation: isolation,
+		},
+	}
+}
+
+func newTestSpecWithResourcePools(name string, isolation Isolation, pools map[string]int) *ExtensionTestSpec {
+	return &ExtensionTestSpec{
+		Name: name,
+		Resources: Resources{
+			Isolation: isolation,
+			ResourcePools:     pools,
 		},
 	}
 }
@@ -99,6 +121,35 @@ func assertAllTestsCompleted(t *testing.T, runner *trackingRunner, want int) {
 	}
 }
 
+func (r *trackingRunner) peakConcurrency() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	type event struct {
+		t     time.Time
+		delta int // +1 for start, -1 for end
+	}
+	var events []event
+	for _, name := range r.testsRun {
+		events = append(events, event{r.startTimes[name], 1})
+		events = append(events, event{r.endTimes[name], -1})
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].t.Equal(events[j].t) {
+			return events[i].delta < events[j].delta // ends before starts at same time
+		}
+		return events[i].t.Before(events[j].t)
+	})
+	peak, running := 0, 0
+	for _, e := range events {
+		running += e.delta
+		if running > peak {
+			peak = running
+		}
+	}
+	return peak
+}
+
 func assertOverlap(t *testing.T, runner *trackingRunner, a, b string, wantOverlap bool, msg string) {
 	t.Helper()
 	got := runner.wereTestsRunningSimultaneously(a, b)
@@ -135,7 +186,7 @@ func TestScheduler_BasicExecution(t *testing.T) {
 	test2 := newTestSpec("test2", Isolation{})
 	test3 := newTestSpec("test3", Isolation{})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1, test2, test3})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3})
 	runner := newTrackingRunner()
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, defaultSchedulerTestWorkers)
@@ -150,7 +201,7 @@ func TestScheduler_ConflictPrevention(t *testing.T) {
 	test2 := newTestSpec("test2", Isolation{Conflict: []string{conflictDatabase}})
 	test3 := newTestSpec("test3", Isolation{Conflict: []string{conflictNetwork}})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1, test2, test3})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3})
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, defaultSchedulerTestWorkers)
 
@@ -166,7 +217,7 @@ func TestScheduler_TaintTolerationBasic(t *testing.T) {
 	testWithoutToleration := newTestSpec("test-without-toleration", Isolation{})
 	testWithToleration := newTestSpec("test-with-toleration", Isolation{Toleration: []string{taintGPU}})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{testWithTaint, testWithoutToleration, testWithToleration})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{testWithTaint, testWithoutToleration, testWithToleration})
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, defaultSchedulerTestWorkers)
 
@@ -188,7 +239,7 @@ func TestScheduler_MultipleTaintsTolerations(t *testing.T) {
 		Toleration: []string{taintGPU, conflictNetwork},
 	})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{testMultipleTaints, testPartialToleration, testFullToleration})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{testMultipleTaints, testPartialToleration, testFullToleration})
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, defaultSchedulerTestWorkers)
 
@@ -212,7 +263,7 @@ func TestScheduler_ConflictsAndTaints(t *testing.T) {
 		Conflict: []string{conflictNetwork},
 	})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{testWithBoth, testConflictingTolerated, testNonConflictingIntolerated})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{testWithBoth, testConflictingTolerated, testNonConflictingIntolerated})
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, defaultSchedulerTestWorkers)
 
@@ -228,7 +279,7 @@ func TestScheduler_NoTaints(t *testing.T) {
 	test2 := newTestSpec("test2", Isolation{})
 	test3 := newTestSpec("test3", Isolation{})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1, test2, test3})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3})
 	ctx := context.Background()
 
 	ranTest1 := scheduler.GetNextTestToRun(ctx)
@@ -252,7 +303,7 @@ func TestScheduler_TaintReferenceCounting(t *testing.T) {
 	toleratingTest := newTestSpec("tolerating-test", Isolation{Toleration: []string{taintGPU}})
 	noTolerationTest := newTestSpec("no-toleration-test", Isolation{})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{taintTest1, taintTest2, toleratingTest, noTolerationTest})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{taintTest1, taintTest2, toleratingTest, noTolerationTest})
 
 	runTestsWithWorkers(context.Background(), scheduler, runner, 3)
 
@@ -266,7 +317,7 @@ func TestScheduler_ContextCancellation(t *testing.T) {
 	test1 := newTestSpec("test1", Isolation{Conflict: []string{conflictBlocker}})
 	test2 := newTestSpec("test2", Isolation{Conflict: []string{conflictBlocker}})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1, test2})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	first := scheduler.GetNextTestToRun(ctx)
@@ -299,7 +350,7 @@ func TestScheduler_ContextCancelledBeforeStart(t *testing.T) {
 
 	test1 := newTestSpec("test1", Isolation{})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1})
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -311,7 +362,7 @@ func TestScheduler_ContextCancelledBeforeStart(t *testing.T) {
 func TestScheduler_EmptyQueue(t *testing.T) {
 	t.Parallel()
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{})
 
 	if result := scheduler.GetNextTestToRun(context.Background()); result != nil {
 		t.Error("expected nil for empty queue")
@@ -323,7 +374,7 @@ func TestScheduler_MaintainsOrderWithConflicts(t *testing.T) {
 	test2 := newTestSpec("test2-conflict-db", Isolation{Conflict: []string{conflictDatabase}})
 	test3 := newTestSpec("test3-no-conflict", Isolation{})
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{test1, test2, test3})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3})
 	ctx := context.Background()
 
 	firstTest := scheduler.GetNextTestToRun(ctx)
@@ -352,7 +403,7 @@ func TestScheduler_DoesNotMutateCallerSlice(t *testing.T) {
 		newTestSpec("B", Isolation{}),
 		newTestSpec("C", Isolation{}),
 	}
-	s := NewScheduler(specs)
+	s := mustNewScheduler(t, specs)
 	for s.GetNextTestToRun(context.Background()) != nil {
 	}
 	seen := map[string]bool{}
@@ -369,6 +420,871 @@ func TestScheduler_DoesNotMutateCallerSlice(t *testing.T) {
 func TestScheduler_NilSpec(t *testing.T) {
 	t.Parallel()
 
-	scheduler := NewScheduler([]*ExtensionTestSpec{})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{})
 	scheduler.MarkTestComplete(nil)
+}
+
+// --- Pool scheduling tests ---
+
+func TestScheduler_PoolCapacityEnforcement(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// Pool has 3 units. Two tests each demand 2 — only one can run at a time.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"res": 2})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+	assertOverlap(t, runner, "test1", "test2", false, "pool capacity prevents overlap")
+}
+
+func TestScheduler_PoolAllowsParallelWhenCapacitySufficient(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// Pool has 4 units. Two tests each demand 2 — both can run simultaneously.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"res": 2})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 4}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+	assertOverlap(t, runner, "test1", "test2", true, "sufficient capacity allows overlap")
+}
+
+func TestScheduler_PoolZeroDemandBypass(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// test1 consumes pool, test2 has no pool demand — runs freely alongside.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 2})
+	test2 := newTestSpec("test2", Isolation{})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 2}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+	assertOverlap(t, runner, "test1", "test2", true, "zero-demand test bypasses pool check")
+}
+
+func TestScheduler_PoolFIFOUnderContention(t *testing.T) {
+	// Pool has 3 units. test1 (demand=3) runs first, consuming all capacity.
+	// test2 (demand=1) and test3 (demand=1) are queued. When test1 completes,
+	// test2 should run before test3 (FIFO order preserved).
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 3})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"res": 1})
+	test3 := newTestSpecWithResourcePools("test3", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	ctx := context.Background()
+
+	// test1 takes all capacity
+	first := scheduler.GetNextTestToRun(ctx)
+	if first == nil || first.Name != "test1" {
+		t.Fatalf("expected test1, got %v", first)
+	}
+
+	// test2 and test3 are blocked — but test2 is first in queue, so when capacity
+	// returns it should be dispatched first. Use a single worker to verify ordering.
+	scheduler.MarkTestComplete(first)
+
+	second := scheduler.GetNextTestToRun(ctx)
+	if second == nil || second.Name != "test2" {
+		t.Fatalf("expected test2 (FIFO), got %v", second)
+	}
+
+	third := scheduler.GetNextTestToRun(ctx)
+	if third == nil || third.Name != "test3" {
+		t.Fatalf("expected test3, got %v", third)
+	}
+}
+
+func TestScheduler_PoolWithConflictsAndTaints(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// test1: uses pool + has taint. test2: uses pool + tolerates taint.
+	// Pool has 4 units, so both could run from a capacity standpoint,
+	// and test2 tolerates the taint, so they should overlap.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{Taint: []string{taintGPU}}, map[string]int{"res": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{Toleration: []string{taintGPU}}, map[string]int{"res": 2})
+	// test3: uses pool but does NOT tolerate taint — blocked by taint, not by pool.
+	test3 := newTestSpecWithResourcePools("test3", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2, test3},
+		WithResourcePoolCapacity(map[string]int{"res": 5}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 3)
+
+	assertAllTestsCompleted(t, runner, 3)
+	assertOverlap(t, runner, "test1", "test2", true, "pool + taint toleration allows overlap")
+	assertOverlap(t, runner, "test1", "test3", false, "taint blocks test3 despite pool capacity")
+}
+
+func TestScheduler_PoolMultiplePools(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// Two pools: "a" (cap=2) and "b" (cap=2).
+	// test1 needs 2 of "a", test2 needs 2 of "b" — different pools, should overlap.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"a": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"b": 2})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"a": 2, "b": 2}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+	assertOverlap(t, runner, "test1", "test2", true, "different pools don't block each other")
+}
+
+func TestScheduler_PoolMultiplePoolsSameTest(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// test1 needs 1 of "a" and 1 of "b". test2 also needs 1 of each.
+	// Both pools have capacity 1, so tests must serialize.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"a": 1, "b": 1})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"a": 1, "b": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"a": 1, "b": 1}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+	assertOverlap(t, runner, "test1", "test2", false, "both pools at capacity prevents overlap")
+}
+
+func TestScheduler_PoolOverDemandRejected(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 5})
+
+	_, err := NewScheduler([]*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+	if err == nil {
+		t.Fatal("expected error for over-demand")
+	}
+	if !strings.Contains(err.Error(), "demands") || !strings.Contains(err.Error(), "capacity") {
+		t.Errorf("expected error about demands exceeding capacity, got: %v", err)
+	}
+}
+
+func TestScheduler_PoolUnknownPoolRejected(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"unknown": 1})
+
+	_, err := NewScheduler([]*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+	if err == nil {
+		t.Fatal("expected error for unknown pool")
+	}
+	if !strings.Contains(err.Error(), "no capacity defined") {
+		t.Errorf("expected error about undefined pool, got: %v", err)
+	}
+}
+
+func TestScheduler_PoolNegativeDemandRejected(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": -1})
+
+	_, err := NewScheduler([]*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+	if err == nil {
+		t.Fatal("expected error for negative demand")
+	}
+	if !strings.Contains(err.Error(), "negative demand") {
+		t.Errorf("expected error about negative demand, got: %v", err)
+	}
+}
+
+func TestScheduler_PoolNegativeCapacityRejected(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpec("test1", Isolation{})
+
+	_, err := NewScheduler([]*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": -1}))
+	if err == nil {
+		t.Fatal("expected error for negative capacity")
+	}
+	if !strings.Contains(err.Error(), "negative capacity") {
+		t.Errorf("expected error about negative capacity, got: %v", err)
+	}
+}
+
+func TestScheduler_PoolNoCapacityConfigured(t *testing.T) {
+	t.Parallel()
+
+	// Tests declare pools but no pool capacity is configured — pools are ignored.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 5})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"res": 5})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2})
+	ctx := context.Background()
+
+	first := scheduler.GetNextTestToRun(ctx)
+	second := scheduler.GetNextTestToRun(ctx)
+
+	if first == nil || second == nil {
+		t.Fatal("without pool capacity configured, all tests should be immediately dispatchable")
+	}
+}
+
+func TestScheduler_PoolConcurrentDispatchComplete(t *testing.T) {
+	runner := newTrackingRunner()
+
+	// 10 tests, each demanding 1 unit from a pool of 3.
+	// With 5 workers, at most 3 should run at once.
+	var specs []*ExtensionTestSpec
+	for i := 0; i < 10; i++ {
+		specs = append(specs, newTestSpecWithResourcePools(
+			fmt.Sprintf("test%d", i), Isolation{}, map[string]int{"res": 1}))
+	}
+
+	scheduler := mustNewScheduler(t, specs,
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 5)
+
+	assertAllTestsCompleted(t, runner, 10)
+
+	if peak := runner.peakConcurrency(); peak > 3 {
+		t.Errorf("peak concurrency was %d, expected at most 3 (pool capacity)", peak)
+	}
+
+	// Verify snapshot shows clean state after all tests complete
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.QueueLength != 0 {
+		t.Errorf("expected empty queue, got %d", snap.QueueLength)
+	}
+	if snap.ActiveCount != 0 {
+		t.Errorf("expected 0 active, got %d", snap.ActiveCount)
+	}
+	if snap.ResourcePoolAvailable["res"] != 3 {
+		t.Errorf("expected pool fully returned (3), got %d", snap.ResourcePoolAvailable["res"])
+	}
+}
+
+func TestScheduler_GetSnapshot(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	diag, ok := scheduler.(SchedulerDiagnostics)
+	if !ok {
+		t.Fatal("scheduler does not implement SchedulerDiagnostics")
+	}
+
+	// Initial snapshot
+	snap := diag.GetSnapshot()
+	if snap.QueueLength != 2 {
+		t.Errorf("expected queue length 2, got %d", snap.QueueLength)
+	}
+	if snap.QueueFront != "test1" {
+		t.Errorf("expected queue front test1, got %q", snap.QueueFront)
+	}
+	if snap.QueueFrontResourcePools["res"] != 2 {
+		t.Errorf("expected queue front resource pools res=2, got %d", snap.QueueFrontResourcePools["res"])
+	}
+	if snap.ResourcePoolCapacity["res"] != 3 {
+		t.Errorf("expected pool capacity 3, got %d", snap.ResourcePoolCapacity["res"])
+	}
+	if snap.ResourcePoolAvailable["res"] != 3 {
+		t.Errorf("expected pool available 3, got %d", snap.ResourcePoolAvailable["res"])
+	}
+	if snap.ActiveCount != 0 {
+		t.Errorf("expected 0 active, got %d", snap.ActiveCount)
+	}
+
+	// Dispatch test1
+	ctx := context.Background()
+	spec := scheduler.GetNextTestToRun(ctx)
+	if spec == nil || spec.Name != "test1" {
+		t.Fatalf("expected test1, got %v", spec)
+	}
+
+	snap = diag.GetSnapshot()
+	if snap.QueueLength != 1 {
+		t.Errorf("expected queue length 1, got %d", snap.QueueLength)
+	}
+	if snap.QueueFront != "test2" {
+		t.Errorf("expected queue front test2, got %q", snap.QueueFront)
+	}
+	if snap.ResourcePoolAvailable["res"] != 1 {
+		t.Errorf("expected pool available 1 (3-2), got %d", snap.ResourcePoolAvailable["res"])
+	}
+	if snap.ActiveCount != 1 {
+		t.Errorf("expected 1 active, got %d", snap.ActiveCount)
+	}
+
+	// Complete test1
+	scheduler.MarkTestComplete(spec)
+
+	snap = diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["res"] != 3 {
+		t.Errorf("expected pool available 3 (returned), got %d", snap.ResourcePoolAvailable["res"])
+	}
+	if snap.ActiveCount != 0 {
+		t.Errorf("expected 0 active, got %d", snap.ActiveCount)
+	}
+}
+
+func TestScheduler_GetSnapshotWithoutPools(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpec("test1", Isolation{})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1})
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.QueueLength != 1 {
+		t.Errorf("expected queue length 1, got %d", snap.QueueLength)
+	}
+	if snap.ResourcePoolCapacity != nil {
+		t.Error("expected nil ResourcePoolCapacity when no pools configured")
+	}
+	if snap.ResourcePoolAvailable != nil {
+		t.Error("expected nil ResourcePoolAvailable when no pools configured")
+	}
+}
+
+func TestScheduler_PoolOptionsThroughRun(t *testing.T) {
+	t.Parallel()
+
+	// Verify that SchedulerOption flows through specs.Run() to NewScheduler.
+	// An invalid pool config should surface as an error from Run().
+	specs := ExtensionTestSpecs{
+		newTestSpecWithResourcePools("over-demand", Isolation{}, map[string]int{"res": 10}),
+	}
+	_, err := specs.Run(context.Background(), NullResultWriter{}, 1,
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+	if err == nil {
+		t.Fatal("expected Run() to return error for over-demand pool config")
+	}
+}
+
+func TestScheduler_WithSchedulerAccessor(t *testing.T) {
+	t.Parallel()
+
+	var captured Scheduler
+	test1 := newTestSpec("test1", Isolation{})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1},
+		WithSchedulerAccessor(func(s Scheduler) {
+			captured = s
+		}))
+
+	if captured == nil {
+		t.Fatal("accessor callback was not invoked")
+	}
+	if captured != scheduler {
+		t.Error("accessor received different scheduler instance")
+	}
+}
+
+func TestScheduler_SchedulerValidationBeforeBeforeAll(t *testing.T) {
+	t.Parallel()
+
+	var beforeAllRan bool
+	specs := ExtensionTestSpecs{
+		newTestSpecWithResourcePools("over-demand", Isolation{}, map[string]int{"res": 10}),
+	}
+	specs[0].Run = func(ctx context.Context) *ExtensionTestResult {
+		return &ExtensionTestResult{Name: "over-demand", Result: ResultPassed}
+	}
+	specs.AddBeforeAll(func() { beforeAllRan = true })
+
+	_, err := specs.Run(context.Background(), NullResultWriter{}, 1,
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+	if err == nil {
+		t.Fatal("expected Run() to return error for over-demand pool config")
+	}
+	if beforeAllRan {
+		t.Error("BeforeAll should not run when scheduler validation fails")
+	}
+}
+
+func TestScheduler_ActiveCountUnderflowGuard(t *testing.T) {
+	t.Parallel()
+
+	spec := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 1})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{spec},
+		WithResourcePoolCapacity(map[string]int{"res": 2}))
+
+	got := scheduler.GetNextTestToRun(context.Background())
+	scheduler.MarkTestComplete(got)
+	scheduler.MarkTestComplete(got) // double complete — should not underflow
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ActiveCount != 0 {
+		t.Errorf("expected activeCount == 0 after double-complete of single test, got %d", snap.ActiveCount)
+	}
+	if snap.ResourcePoolAvailable["res"] > snap.ResourcePoolCapacity["res"] {
+		t.Errorf("pool over-returned: available %d > capacity %d",
+			snap.ResourcePoolAvailable["res"], snap.ResourcePoolCapacity["res"])
+	}
+}
+
+func TestScheduler_PoolDemandExceedsAvailableBlocksUntilCapacityReturned(t *testing.T) {
+	t.Parallel()
+
+	// Pool capacity is 3. Two tests: one demands 2, the other demands 2.
+	// Both fit within total capacity (2 <= 3), but they can't run simultaneously
+	// because 2+2=4 > 3. The second must wait until the first completes.
+	test1 := newTestSpecWithResourcePools("needs2-a", Isolation{}, map[string]int{"res": 2})
+	test2 := newTestSpecWithResourcePools("needs2-b", Isolation{}, map[string]int{"res": 2})
+
+	runner := newTrackingRunner()
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+
+	if peak := runner.peakConcurrency(); peak > 1 {
+		t.Errorf("peak concurrency was %d, expected at most 1 (each test needs 2 of 3 pool units)", peak)
+	}
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["res"] != 3 {
+		t.Errorf("expected pool fully returned (3), got %d", snap.ResourcePoolAvailable["res"])
+	}
+}
+
+func TestScheduler_PoolBlockedHeadSkipsToRunnableTest(t *testing.T) {
+	t.Parallel()
+
+	// Pre-dispatch a holder that consumes 2 of 3 capacity, leaving 1 available.
+	// Queue: [big(3), small(1)]. big needs 3 but only 1 available — blocked.
+	// Scheduler must skip big and dispatch small (needs 1, 1 >= 1).
+	holder := newTestSpecWithResourcePools("holder", Isolation{}, map[string]int{"res": 2})
+	big := newTestSpecWithResourcePools("big", Isolation{}, map[string]int{"res": 3})
+	small := newTestSpecWithResourcePools("small", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{holder, big, small},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	ctx := context.Background()
+
+	// Dispatch holder — consumes 2 units, leaving 1 available
+	got := scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "holder" {
+		t.Fatalf("expected holder, got %v", got)
+	}
+
+	// Next dispatch: big(3) is at head but needs 3, only 1 available.
+	// Scheduler must skip to small(1).
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "small" {
+		t.Fatalf("expected scheduler to skip blocked big and dispatch small, got %v", got)
+	}
+
+	// Complete holder — returns 2 units, now 3 available. big can run.
+	scheduler.MarkTestComplete(holder)
+	scheduler.MarkTestComplete(small)
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "big" {
+		t.Fatalf("expected big after capacity returned, got %v", got)
+	}
+}
+
+func TestScheduler_PoolBlockedHeadDoesNotStarveQueue(t *testing.T) {
+	t.Parallel()
+
+	// Pre-dispatch holder consuming 1 of 2 capacity, leaving 1 available.
+	// Queue: [big(2), small-a(1), small-b(1)].
+	// big needs 2 but only 1 available — blocked at head.
+	// Scheduler must skip big and dispatch small-a, then small-b blocks (0 left).
+	// After holder and small-a complete, big runs.
+	holder := newTestSpecWithResourcePools("holder", Isolation{}, map[string]int{"res": 1})
+	big := newTestSpecWithResourcePools("big", Isolation{}, map[string]int{"res": 2})
+	smallA := newTestSpecWithResourcePools("small-a", Isolation{}, map[string]int{"res": 1})
+	smallB := newTestSpecWithResourcePools("small-b", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{holder, big, smallA, smallB},
+		WithResourcePoolCapacity(map[string]int{"res": 2}))
+
+	ctx := context.Background()
+
+	// Dispatch holder — consumes 1 unit, 1 available
+	got := scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "holder" {
+		t.Fatalf("expected holder, got %v", got)
+	}
+
+	// big(2) is head but blocked (only 1 available). Skip to small-a(1).
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "small-a" {
+		t.Fatalf("expected small-a (skip blocked big), got %v", got)
+	}
+
+	// Now 0 available — complete holder to free 1 unit
+	scheduler.MarkTestComplete(holder)
+
+	// small-b(1) should now be dispatchable (1 available, big still needs 2)
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "small-b" {
+		t.Fatalf("expected small-b (skip blocked big again), got %v", got)
+	}
+
+	// Complete both smalls — returns 2 units, big can finally run
+	scheduler.MarkTestComplete(smallA)
+	scheduler.MarkTestComplete(smallB)
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil || got.Name != "big" {
+		t.Fatalf("expected big after all capacity returned, got %v", got)
+	}
+}
+
+func TestScheduler_ContextCancelWithMultipleBlockedWorkers(t *testing.T) {
+	t.Parallel()
+
+	// Pool capacity 1, 3 tests each needing 1 unit, 3 workers.
+	// Only 1 test can run at a time. Cancel context mid-flight.
+	// All workers must exit without deadlock.
+	specs := make([]*ExtensionTestSpec, 3)
+	for i := range specs {
+		specs[i] = newTestSpecWithResourcePools(
+			fmt.Sprintf("test%d", i), Isolation{}, map[string]int{"res": 1})
+	}
+
+	runner := newTrackingRunner()
+	scheduler := mustNewScheduler(t, specs,
+		WithResourcePoolCapacity(map[string]int{"res": 1}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay — enough for at least 1 test to dispatch
+	go func() {
+		time.Sleep(3 * schedulerTestDelay)
+		cancel()
+	}()
+
+	runTestsWithWorkers(ctx, scheduler, runner, 3)
+
+	// Some tests may have completed, but the key assertion is no deadlock:
+	// if we reach this line, all 3 workers exited cleanly.
+	completed := len(runner.getTestsRun())
+	if completed < 1 {
+		t.Error("expected at least 1 test to complete before cancellation")
+	}
+	if completed > 3 {
+		t.Errorf("completed %d tests but only 3 exist", completed)
+	}
+}
+
+func TestScheduler_PoolCapacityOneSerializesAllTests(t *testing.T) {
+	t.Parallel()
+
+	// Pool capacity=1, 5 tests each needing 1 unit, 3 workers.
+	// Every test must wait for the previous to complete — strict serialization.
+	specs := make([]*ExtensionTestSpec, 5)
+	for i := range specs {
+		specs[i] = newTestSpecWithResourcePools(
+			fmt.Sprintf("test%d", i), Isolation{}, map[string]int{"res": 1})
+	}
+
+	runner := newTrackingRunner()
+	scheduler := mustNewScheduler(t, specs,
+		WithResourcePoolCapacity(map[string]int{"res": 1}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 3)
+
+	assertAllTestsCompleted(t, runner, 5)
+
+	if peak := runner.peakConcurrency(); peak > 1 {
+		t.Errorf("peak concurrency was %d, expected 1 (pool capacity=1 forces serialization)", peak)
+	}
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["res"] != 1 {
+		t.Errorf("expected pool fully returned (1), got %d", snap.ResourcePoolAvailable["res"])
+	}
+}
+
+func TestScheduler_PoolZeroDemandDispatches(t *testing.T) {
+	t.Parallel()
+
+	// A test declaring zero demand for a pool should pass validation and dispatch normally.
+	test1 := newTestSpecWithResourcePools("zero-demand", Isolation{}, map[string]int{"res": 0})
+	test2 := newTestSpecWithResourcePools("normal", Isolation{}, map[string]int{"res": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	ctx := context.Background()
+	first := scheduler.GetNextTestToRun(ctx)
+	second := scheduler.GetNextTestToRun(ctx)
+
+	if first == nil || second == nil {
+		t.Fatal("both tests should be dispatchable")
+	}
+}
+
+func TestScheduler_PoolOverflowCapExactValue(t *testing.T) {
+	t.Parallel()
+
+	// Double-complete should cap poolAvailable at exactly poolCapacity, not above.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 2})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": 3}))
+
+	ctx := context.Background()
+	spec := scheduler.GetNextTestToRun(ctx)
+	if spec == nil {
+		t.Fatal("test should be dispatchable")
+	}
+
+	scheduler.MarkTestComplete(spec)
+	scheduler.MarkTestComplete(spec) // double-complete
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["res"] != snap.ResourcePoolCapacity["res"] {
+		t.Errorf("after double-complete, available should equal capacity (%d), got %d",
+			snap.ResourcePoolCapacity["res"], snap.ResourcePoolAvailable["res"])
+	}
+	if snap.ActiveCount != 0 {
+		t.Errorf("after double-complete, activeCount should be 0, got %d", snap.ActiveCount)
+	}
+}
+
+func TestScheduler_MarkTestCompleteNeverDispatched(t *testing.T) {
+	t.Parallel()
+
+	// Calling MarkTestComplete on a spec that was never dispatched should not panic.
+	test1 := newTestSpec("dispatched", Isolation{
+		Conflict: []string{conflictDatabase},
+	})
+	test2 := newTestSpec("never-dispatched", Isolation{
+		Conflict: []string{conflictNetwork},
+	})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2})
+
+	ctx := context.Background()
+	dispatched := scheduler.GetNextTestToRun(ctx)
+	if dispatched == nil {
+		t.Fatal("first test should be dispatchable")
+	}
+
+	// Complete the never-dispatched spec — should not panic
+	scheduler.MarkTestComplete(test2)
+
+	// Original dispatched test should still complete normally
+	scheduler.MarkTestComplete(dispatched)
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ActiveCount < 0 {
+		t.Errorf("activeCount should not go negative, got %d", snap.ActiveCount)
+	}
+}
+
+func TestScheduler_PoolZeroCapacityRejectsDemand(t *testing.T) {
+	t.Parallel()
+
+	// A pool with capacity 0 should reject any test demanding > 0 units.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"res": 1})
+
+	_, err := NewScheduler([]*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"res": 0}))
+	if err == nil {
+		t.Fatal("expected error for demand exceeding zero-capacity pool")
+	}
+	if !strings.Contains(err.Error(), "demands") || !strings.Contains(err.Error(), "capacity") {
+		t.Errorf("expected error about demands exceeding capacity, got: %v", err)
+	}
+}
+
+func TestScheduler_GoroutineCleanupAfterManyDispatches(t *testing.T) {
+	t.Parallel()
+
+	// Each GetNextTestToRun spawns a goroutine for context cancellation.
+	// Verify goroutines are cleaned up after many dispatch cycles.
+	specs := make([]*ExtensionTestSpec, 50)
+	for i := range specs {
+		specs[i] = newTestSpec(fmt.Sprintf("test%d", i), Isolation{})
+	}
+
+	scheduler := mustNewScheduler(t, specs)
+	ctx := context.Background()
+
+	for {
+		spec := scheduler.GetNextTestToRun(ctx)
+		if spec == nil {
+			break
+		}
+		scheduler.MarkTestComplete(spec)
+	}
+
+	// Allow goroutines time to exit via the closed done channel
+	time.Sleep(5 * time.Millisecond)
+
+	// No deadlock and all tests dispatched is the primary assertion.
+	// A goroutine leak would eventually cause resource exhaustion in long-running
+	// processes, but we can't assert an exact count without flakiness.
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.QueueLength != 0 {
+		t.Errorf("expected empty queue, got %d", snap.QueueLength)
+	}
+	if snap.ActiveCount != 0 {
+		t.Errorf("expected 0 active, got %d", snap.ActiveCount)
+	}
+}
+
+func TestScheduler_TaintCleanupAfterAllComplete(t *testing.T) {
+	t.Parallel()
+
+	// Two taint-emitting tests followed by an intolerant test.
+	// After both taint tests complete, the intolerant test must run,
+	// proving taints are fully cleaned up (not left at count=0 in the map).
+	taint1 := newTestSpec("taint1", Isolation{Taint: []string{taintGPU}})
+	taint2 := newTestSpec("taint2", Isolation{Taint: []string{taintGPU}})
+	intolerant := newTestSpec("intolerant", Isolation{})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{taint1, taint2, intolerant})
+	ctx := context.Background()
+
+	// Dispatch and complete taint1
+	got := scheduler.GetNextTestToRun(ctx)
+	if got.Name != "taint1" {
+		t.Fatalf("expected taint1, got %s", got.Name)
+	}
+	scheduler.MarkTestComplete(got)
+
+	// Dispatch and complete taint2
+	got = scheduler.GetNextTestToRun(ctx)
+	if got.Name != "taint2" {
+		t.Fatalf("expected taint2, got %s", got.Name)
+	}
+	scheduler.MarkTestComplete(got)
+
+	// Intolerant test should now run — taint is fully cleaned up
+	got = scheduler.GetNextTestToRun(ctx)
+	if got == nil {
+		t.Fatal("intolerant test should be dispatchable after all taints cleared")
+	}
+	if got.Name != "intolerant" {
+		t.Fatalf("expected intolerant, got %s", got.Name)
+	}
+}
+
+func TestScheduler_PoolMultiPoolPartialExhaustion(t *testing.T) {
+	t.Parallel()
+
+	// Test demands pool "a":1 and "b":2. Capacities: "a":5, "b":2.
+	// First dispatch consumes all of pool "b". Second test also needs "b":2
+	// and must block despite "a" having ample capacity.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"a": 1, "b": 2})
+	test2 := newTestSpecWithResourcePools("test2", Isolation{}, map[string]int{"a": 1, "b": 2})
+
+	runner := newTrackingRunner()
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1, test2},
+		WithResourcePoolCapacity(map[string]int{"a": 5, "b": 2}))
+
+	runTestsWithWorkers(context.Background(), scheduler, runner, 2)
+
+	assertAllTestsCompleted(t, runner, 2)
+
+	// Tests must run serially — pool "b" can only serve one at a time
+	if peak := runner.peakConcurrency(); peak > 1 {
+		t.Errorf("peak concurrency was %d, expected 1 (pool 'b' exhausted by single test)", peak)
+	}
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["a"] != 5 {
+		t.Errorf("pool 'a' should be fully returned (5), got %d", snap.ResourcePoolAvailable["a"])
+	}
+	if snap.ResourcePoolAvailable["b"] != 2 {
+		t.Errorf("pool 'b' should be fully returned (2), got %d", snap.ResourcePoolAvailable["b"])
+	}
+}
+
+func TestScheduler_GetSnapshotEmptyQueue(t *testing.T) {
+	t.Parallel()
+
+	test1 := newTestSpec("test1", Isolation{})
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1})
+
+	ctx := context.Background()
+	got := scheduler.GetNextTestToRun(ctx)
+	if got == nil {
+		t.Fatal("test should be dispatchable")
+	}
+	scheduler.MarkTestComplete(got)
+
+	// Queue is now drained — snapshot should reflect empty state
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.QueueLength != 0 {
+		t.Errorf("expected queue length 0, got %d", snap.QueueLength)
+	}
+	if snap.QueueFront != "" {
+		t.Errorf("expected empty QueueFront, got %q", snap.QueueFront)
+	}
+	if snap.QueueFrontResourcePools != nil {
+		t.Errorf("expected nil QueueFrontResourcePools, got %v", snap.QueueFrontResourcePools)
+	}
+}
+
+func TestScheduler_PoolMultiPoolDoubleCompleteOverflowCap(t *testing.T) {
+	t.Parallel()
+
+	// Test demands from two pools. Double-complete should cap each pool independently.
+	test1 := newTestSpecWithResourcePools("test1", Isolation{}, map[string]int{"a": 2, "b": 1})
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{test1},
+		WithResourcePoolCapacity(map[string]int{"a": 3, "b": 2}))
+
+	ctx := context.Background()
+	spec := scheduler.GetNextTestToRun(ctx)
+	if spec == nil {
+		t.Fatal("test should be dispatchable")
+	}
+
+	scheduler.MarkTestComplete(spec)
+	scheduler.MarkTestComplete(spec) // double-complete
+
+	diag := scheduler.(SchedulerDiagnostics)
+	snap := diag.GetSnapshot()
+	if snap.ResourcePoolAvailable["a"] != 3 {
+		t.Errorf("pool 'a' should be capped at capacity (3), got %d", snap.ResourcePoolAvailable["a"])
+	}
+	if snap.ResourcePoolAvailable["b"] != 2 {
+		t.Errorf("pool 'b' should be capped at capacity (2), got %d", snap.ResourcePoolAvailable["b"])
+	}
+}
+
+func TestScheduler_DiagnosticsTypeAssertion(t *testing.T) {
+	t.Parallel()
+
+	scheduler := mustNewScheduler(t, []*ExtensionTestSpec{newTestSpec("test1", Isolation{})})
+
+	if _, ok := scheduler.(SchedulerDiagnostics); !ok {
+		t.Error("scheduler should implement SchedulerDiagnostics")
+	}
 }

--- a/pkg/extension/extensiontests/spec.go
+++ b/pkg/extension/extensiontests/spec.go
@@ -199,16 +199,9 @@ func (specs ExtensionTestSpecs) Names() []string {
 //
 // Tests are scheduled using isolation-aware scheduling that respects conflicts, taints, and
 // tolerations defined in each spec's Resources.Isolation field.
-func (specs ExtensionTestSpecs) Run(ctx context.Context, w ResultWriter, maxConcurrent int) ([]*ExtensionTestResult, error) {
+func (specs ExtensionTestSpecs) Run(ctx context.Context, w ResultWriter, maxConcurrent int, opts ...SchedulerOption) ([]*ExtensionTestResult, error) {
 	terminalFailures := atomic.Int64{}
 	nonTerminalFailures := atomic.Int64{}
-
-	// Execute beforeAll
-	for _, spec := range specs {
-		for _, beforeAllTask := range spec.beforeAll {
-			beforeAllTask.Run()
-		}
-	}
 
 	// if we have only a single spec to run, we do that differently than running multiple.
 	// multiple specs can run in parallel and do so by exec-ing back into the binary with `run-test` with a single test to execute.
@@ -216,8 +209,19 @@ func (specs ExtensionTestSpecs) Run(ctx context.Context, w ResultWriter, maxConc
 	// we need to run it in process.
 	runSingleSpec := len(specs) == 1
 
-	// Create scheduler with isolation-aware scheduling
-	scheduler := NewScheduler(specs)
+	// Create scheduler before BeforeAll hooks so validation errors don't leave
+	// setup side effects without cleanup.
+	scheduler, err := NewScheduler(specs, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create scheduler: %w", err)
+	}
+
+	// Execute beforeAll
+	for _, spec := range specs {
+		for _, beforeAllTask := range spec.beforeAll {
+			beforeAllTask.Run()
+		}
+	}
 
 	// Start consumers
 	var wg sync.WaitGroup

--- a/pkg/extension/extensiontests/types.go
+++ b/pkg/extension/extensiontests/types.go
@@ -72,10 +72,11 @@ type ExtensionTestSpec struct {
 }
 
 type Resources struct {
-	Isolation Isolation `json:"isolation"`
-	Memory    string    `json:"memory,omitempty"`
-	Duration  string    `json:"duration,omitempty"`
-	Timeout   string    `json:"timeout,omitempty"`
+	Isolation Isolation      `json:"isolation"`
+	ResourcePools map[string]int `json:"resourcePools,omitempty"`
+	Memory    string         `json:"memory,omitempty"`
+	Duration  string         `json:"duration,omitempty"`
+	Timeout   string         `json:"timeout,omitempty"`
 }
 
 type Isolation struct {

--- a/pkg/extension/types.go
+++ b/pkg/extension/types.go
@@ -81,6 +81,9 @@ type Suite struct {
 	ClusterStability ClusterStability `json:"clusterStability,omitempty"`
 	// TestTimeout is the default timeout for tests in this suite.
 	TestTimeout *time.Duration `json:"testTimeout,omitempty"`
+	// ResourcePools defines the total capacity of named resource pools for this suite.
+	// The scheduler enforces that parallel test demand does not exceed pool capacity.
+	ResourcePools map[string]int `json:"resourcePools,omitempty"`
 }
 
 type Image struct {


### PR DESCRIPTION
Jira:
https://redhat.atlassian.net/browse/ARO-26723

This PR adds generic named resource pools (map[string]int) to the OTE scheduler. Tests declare per-pool demand, suites declare total capacity, and the scheduler gates dispatch so parallel demand never exceeds capacity. All changes are backward-compatible via variadic SchedulerOption and omitempty JSON tags.

- Generic pools: map[string]int natively supports N named resources, not just MI containers
- Startup validation: NewScheduler() returns error for over-demand, unknown pool, negative demand (prevents structural deadlock)
- FIFO scan: no priority or backfill; blocked tests wait in queue order
- Delta logging: one stderr line per dispatch/complete per pool (two lines per test total)
- GetSnapshot(): exposes queue front, pool state, and active count for external stall detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional suite-level named resource pools to cap parallel extension test demand.
  * Extension test execution now supports resource-pool–aware dispatch (in addition to existing `--max-concurrency` parallelism).
  * Added scheduler diagnostics/snapshots (queue/front plus pool capacity/availability and active count).
* **Bug Fixes**
  * Enforced stricter validation for pool configuration and test demands (unknown/negative/over-demand/zero-capacity), with fail-fast behavior before `beforeAll`.
  * Correctly reserves/release pool capacity on dispatch/completion, including overflow/underflow safeguards and improved blocked/contended scheduling behavior.
* **Documentation**
  * Updated JSON schema/docs to describe the new `resourcePools` suite field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->