### PR TITLE
Report timeout as structured error instead of deserialization failure

### DIFF
--- a/pkg/ginkgo/parallel.go
+++ b/pkg/ginkgo/parallel.go
@@ -15,11 +15,17 @@ import (
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
 )
 
+// parentGracePeriod is extra time the parent waits beyond the child's
+// --timeout before sending SIGINT, so the child can exit cooperatively
+// (e.g. via NodeTimeout) before the parent escalates.
+const parentGracePeriod = 2 * time.Minute
+
 func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Duration) *extensiontests.ExtensionTestResult {
+	parentTimeout := timeout + parentGracePeriod
 	// longerCtx is used to backstop the process, but leave termination up to us if possible to allow a double interrupt
-	longerCtx, longerCancel := context.WithTimeout(ctx, timeout+15*time.Minute)
+	longerCtx, longerCancel := context.WithTimeout(ctx, parentTimeout+15*time.Minute)
 	defer longerCancel()
-	timeoutCtx, shorterCancel := context.WithTimeout(longerCtx, timeout)
+	timeoutCtx, shorterCancel := context.WithTimeout(longerCtx, parentTimeout)
 	defer shorterCancel()
 
 	stdout := &bytes.Buffer{}
@@ -39,7 +45,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 	go func() {
 		// interrupt after timeout, or exit early if the process finishes first
 		select {
-		case <-time.After(timeout):
+		case <-time.After(parentTimeout):
 		case <-timeoutCtx.Done():
 		}
 		if command.Process != nil {
@@ -56,8 +62,8 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 		}
 	}()
 
-	result := extensiontests.ResultFailed
 	cmdErr := command.Wait()
+	end := time.Now()
 
 	subcommandResult, parseErr := newTestResultFromOutput(stdout)
 	if parseErr == nil {
@@ -67,7 +73,7 @@ func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Du
 
 	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
 	fmt.Fprintf(stderr, "Deserialization Error: %v\n", parseErr)
-	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
+	return newTestResult(testName, extensiontests.ResultFailed, start, end, stdout, stderr)
 }
 
 func newTestResultFromOutput(stdout *bytes.Buffer) (*extensiontests.ExtensionTestResult, error) {

--- a/test/example/example.go
+++ b/test/example/example.go
@@ -60,4 +60,11 @@ var _ = Describe("[sig-testing] openshift-tests-extension", func() {
 		// This test is pending (XIt) and should be reported as skipped, not panic.
 		Expect(true).To(BeTrue())
 	})
+
+	It("should report structured timeout for node timeout", NodeTimeout(3*time.Second), func(ctx SpecContext) {
+		select {
+		case <-time.After(time.Minute):
+		case <-ctx.Done():
+		}
+	})
 })

--- a/test/framework/run.go
+++ b/test/framework/run.go
@@ -67,6 +67,19 @@ var _ = Describe("[sig-testing] example-tests run-suite", Label("framework"), fu
 		Expect(foundPending).To(BeTrue(), "Expected pending test (XIt) to be reported as skipped")
 	})
 
+	It("should have structured timeout output for a timed-out test", func() {
+		var found bool
+		for _, test := range result {
+			if test.Name == "[sig-testing] openshift-tests-extension should report structured timeout for node timeout" && test.Result == "failed" {
+				found = true
+				Expect(test.Error).To(ContainSubstring("A node timeout occurred"), "Expected Ginkgo's structured timeout message")
+				Expect(test.Error).NotTo(ContainSubstring("Deserialization Error"), "Timeout should not fall through to generic parse error")
+				break
+			}
+		}
+		Expect(found).To(BeTrue(), "Expected the timed-out test result to be present with structured timeout info")
+	})
+
 	It("fast suite should not have a slow test", func() {
 		foundTest := false
 		for _, test := range result {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25369

When a test subprocess times out and is killed, the parent can't parse its output and reports a generic "Deserialization Error" indistinguishable from a non-timeout crash.

This branch tracks whether the signal escalation goroutine fired due to a timeout using an atomic flag (set before SIGINT to avoid a race), and when it did, replaces the generic error with "test timed out after <duration>; subprocess exit: <status>" so CI tools like Sippy can identify timeout failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved tracking of timeout escalation for long-running processes, ensuring consistent timeout/timing behavior.
  * Enhanced failure diagnostics when escalation occurs by including timeout-specific stderr details.
  * Preserved successfully parsed results even if escalation happened; improved handling and reporting when output parsing fails.

* **Tests**
  * Added unit tests covering output parsing, result construction (timing/output/error), grace period validation, and timeout-related error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->